### PR TITLE
chore: Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
-  <img width="200" height="200" src="./images/yates-icon.png">
+  <img width="200" height="200" src="https://raw.githubusercontent.com/cerebruminc/yates/master/images/yates-icon.png">
 
-[![npm version](https://badge.fury.io/js/cerebruminc/yates.svg)](https://badge.fury.io/js/cerebruminc/yates)
+[![npm version](https://img.shields.io/npm/v/@cerebruminc/yates)](https://www.npmjs.com/package/@cerebruminc/yates)
 
   <h1>Yates = Prisma + RLS</h1>
 


### PR DESCRIPTION
The icon source has been change to a full URL so that it works correctly on NPM.

Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>