### PR TITLE
fix: Don't rerun middleware when applying RLC policies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,11 @@
       },
       "devDependencies": {
         "@prisma/client": "^4.0.0",
+        "@types/cls-hooked": "^4.3.3",
         "@types/jest": "^29.2.6",
         "@types/lodash": "^4.14.191",
         "@types/uuid": "^9.0.0",
+        "cls-hooked": "^4.2.2",
         "jest": "^29.3.1",
         "prisma": "^4.9.0",
         "rome": "^11.0.0",
@@ -1140,6 +1142,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "node_modules/@types/cls-hooked": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.3.tgz",
+      "integrity": "sha512-gNstDTb/ty5h6gJd6YpSPgsLX9LmRpaKJqGFp7MRlYxhwp4vXXKlJ9+bt1TZ9KbVNXE+Mbxy2AYXcpY21DDtJw==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -1286,6 +1297,18 @@
       "dev": true,
       "dependencies": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "dev": true,
+      "dependencies": {
+        "stack-chain": "^1.3.7"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3"
       }
     },
     "node_modules/babel-jest": {
@@ -1556,6 +1579,29 @@
         "node": ">=12"
       }
     },
+    "node_modules/cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "dev": true,
+      "dependencies": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      },
+      "engines": {
+        "node": "^4.7 || >=6.9 || >=7.3 || >=8.2.1"
+      }
+    },
+    "node_modules/cls-hooked/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -1671,6 +1717,15 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
+    },
+    "node_modules/emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "dev": true,
+      "dependencies": {
+        "shimmer": "^1.2.0"
+      }
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -3271,6 +3326,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "dev": true
+    },
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -3315,6 +3376,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
+    },
+    "node_modules/stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==",
       "dev": true
     },
     "node_modules/stack-utils": {
@@ -4591,6 +4658,15 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/cls-hooked": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@types/cls-hooked/-/cls-hooked-4.3.3.tgz",
+      "integrity": "sha512-gNstDTb/ty5h6gJd6YpSPgsLX9LmRpaKJqGFp7MRlYxhwp4vXXKlJ9+bt1TZ9KbVNXE+Mbxy2AYXcpY21DDtJw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/graceful-fs": {
       "version": "4.1.6",
       "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.6.tgz",
@@ -4718,6 +4794,15 @@
       "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
+      }
+    },
+    "async-hook-jl": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/async-hook-jl/-/async-hook-jl-1.7.6.tgz",
+      "integrity": "sha512-gFaHkFfSxTjvoxDMYqDuGHlcRyUuamF8s+ZTtJdDzqjws4mCt7v0vuV79/E2Wr2/riMQgtG4/yUtXWs1gZ7JMg==",
+      "dev": true,
+      "requires": {
+        "stack-chain": "^1.3.7"
       }
     },
     "babel-jest": {
@@ -4908,6 +4993,25 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "cls-hooked": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/cls-hooked/-/cls-hooked-4.2.2.tgz",
+      "integrity": "sha512-J4Xj5f5wq/4jAvcdgoGsL3G103BtWpZrMo8NEinRltN+xpTZdI+M38pyQqhuFU/P792xkMFvnKSf+Lm81U1bxw==",
+      "dev": true,
+      "requires": {
+        "async-hook-jl": "^1.7.6",
+        "emitter-listener": "^1.0.1",
+        "semver": "^5.4.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -4996,6 +5100,15 @@
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
       "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
       "dev": true
+    },
+    "emitter-listener": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.1.2.tgz",
+      "integrity": "sha512-Bt1sBAGFHY9DKY+4/2cV6izcKJUf5T7/gkdmkxzX/qv9CcGH8xSwVRW5mtX03SWJtRTWSOpzCuWN9rBFYZepZQ==",
+      "dev": true,
+      "requires": {
+        "shimmer": "^1.2.0"
+      }
     },
     "emittery": {
       "version": "0.13.1",
@@ -6191,6 +6304,12 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
+    "shimmer": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
+      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw==",
+      "dev": true
+    },
     "signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
@@ -6229,6 +6348,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true
+    },
+    "stack-chain": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/stack-chain/-/stack-chain-1.3.7.tgz",
+      "integrity": "sha512-D8cWtWVdIe/jBA7v5p5Hwl5yOSOrmZPWDPe2KxQ5UAGD+nxbxU0lKXA4h85Ta6+qgdKVL3vUxsbIZjc1kBG7ug==",
       "dev": true
     },
     "stack-utils": {

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
   "license": "MIT",
   "devDependencies": {
     "@prisma/client": "^4.0.0",
+    "@types/cls-hooked": "^4.3.3",
     "@types/jest": "^29.2.6",
     "@types/lodash": "^4.14.191",
     "@types/uuid": "^9.0.0",
+    "cls-hooked": "^4.2.2",
     "jest": "^29.3.1",
     "prisma": "^4.9.0",
     "rome": "^11.0.0",

--- a/test/integration/middleware.spec.ts
+++ b/test/integration/middleware.spec.ts
@@ -1,0 +1,103 @@
+import { PrismaClient, Prisma } from "@prisma/client";
+import { createNamespace } from "cls-hooked";
+import { v4 as uuid } from "uuid";
+import { setup } from "../../src";
+
+let adminClient: PrismaClient;
+
+beforeAll(async () => {
+	adminClient = new PrismaClient();
+});
+
+describe("middlewares", () => {
+	it("should not run twice", async () => {
+		const prisma = new PrismaClient();
+
+		const middlewareSpy = jest.fn(async (params, next) => {
+			return next(params);
+		});
+
+		prisma.$use(middlewareSpy);
+
+		const role = `USER_${uuid()}`;
+
+		await setup({
+			prisma,
+			getRoles(abilities) {
+				return {
+					[role]: [abilities.Post.read, abilities.Post.create],
+				};
+			},
+			getContext: () => {
+				return {
+					role,
+					context: {},
+				};
+			},
+		});
+
+		middlewareSpy.mockClear();
+
+		const post = await prisma.post.create({
+			data: {
+				title: `Test post from ${role}`,
+			},
+		});
+
+		expect(post.id).toBeDefined();
+		expect(middlewareSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("should not be able to bypass RBAC when using cls-hooked", async () => {
+		const prisma = new PrismaClient();
+
+		const middleware: Prisma.Middleware = async (params, next) => {
+			if (params.model === "Post") {
+				const post = await next(params);
+				return post;
+			} else {
+				return next(params);
+			}
+		};
+
+		const clsSession = createNamespace("test");
+
+		prisma.$use(middleware);
+
+		const roleName = `USER_${uuid()}`;
+
+		await setup({
+			prisma,
+			getRoles(abilities) {
+				return {
+					[roleName]: [abilities.Post.read],
+				};
+			},
+			getContext: () => {
+				const role = clsSession.get("role");
+				return {
+					role,
+					context: {},
+				};
+			},
+		});
+
+		await expect(
+			new Promise((res, reject) => {
+				clsSession.run(async () => {
+					try {
+						clsSession.set("role", roleName);
+						const result = await prisma.post.create({
+							data: {
+								title: `Test post from ${roleName}`,
+							},
+						});
+						res(result);
+					} catch (e) {
+						reject(e);
+					}
+				});
+			}),
+		).rejects.toThrow();
+	});
+});


### PR DESCRIPTION
This change fixes an issue where middlewares created by the client would be run multiple times per query.

Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>