### PR TITLE
fix: Use privileged Prisma client when setting config in transaction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export const setupMiddleware = (prisma: PrismaClient, getContext: GetContextFn) 
 				// Now set all the context variables using `set_config` so that they can be used in RLS
 				...toPairs(context).map(([key, value]) => {
 					const keySafe = key.replace(/[^a-z_\.]/g, "");
-					return prisma.$queryRaw`SELECT set_config(${keySafe}, ${value},  true);`;
+					return adminClient.$queryRaw`SELECT set_config(${keySafe}, ${value},  true);`;
 				}),
 				...[
 					// Now call original function

--- a/test/integration/index.spec.ts
+++ b/test/integration/index.spec.ts
@@ -1,39 +1,79 @@
 import { PrismaClient } from "@prisma/client";
+import { v4 as uuid } from "uuid";
 import { setup } from "../../src";
 
 describe("setup", () => {
-  describe("params.getRoles()", () => {
-    it("should provide a set of built-in abilities for CRUD operations", async () => {
-      const prisma = new PrismaClient();
+	describe("params.getRoles()", () => {
+		it("should provide a set of built-in abilities for CRUD operations", async () => {
+			const prisma = new PrismaClient();
 
-      const getRoles = jest.fn((_abilities) => {
-        return {
-          USER: "*",
-        } as any;
-      });
+			const getRoles = jest.fn((_abilities) => {
+				return {
+					USER: "*",
+				} as any;
+			});
 
-      await setup({
-        prisma,
-        getRoles,
-        getContext: () => null,
-      });
+			await setup({
+				prisma,
+				getRoles,
+				getContext: () => null,
+			});
 
-      expect(getRoles.mock.calls).toHaveLength(1);
-      const abilities = getRoles.mock.calls[0][0];
+			expect(getRoles.mock.calls).toHaveLength(1);
+			const abilities = getRoles.mock.calls[0][0];
 
-      expect(Object.keys(abilities)).toStrictEqual(["User", "Post"]);
-      expect(Object.keys(abilities.User)).toStrictEqual([
-        "create",
-        "read",
-        "update",
-        "delete",
-      ]);
-      expect(Object.keys(abilities.Post)).toStrictEqual([
-        "create",
-        "read",
-        "update",
-        "delete",
-      ]);
-    });
-  });
+			expect(Object.keys(abilities)).toStrictEqual(["User", "Post"]);
+			expect(Object.keys(abilities.User)).toStrictEqual(["create", "read", "update", "delete"]);
+			expect(Object.keys(abilities.Post)).toStrictEqual(["create", "read", "update", "delete"]);
+		});
+	});
+
+	describe("params.getContext()", () => {
+		it("should allow a custom context to be set", async () => {
+			const prisma = new PrismaClient();
+
+			const role = `USER_${uuid()}`;
+
+			const postTitle = `Test post from ${role}`;
+
+			await setup({
+				prisma,
+				customAbilities: {
+					Post: {
+						createWithTitle: {
+							description: "Test Post Create",
+							operation: "INSERT",
+							expression: "current_setting('post.title') = title",
+						},
+						readWithTitle: {
+							description: "Test Post Read",
+							operation: "SELECT",
+							expression: "current_setting('post.title') = title",
+						},
+					},
+				},
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.Post.createWithTitle, abilities.Post.readWithTitle],
+					};
+				},
+				getContext: () => {
+					return {
+						role,
+						context: {
+							"post.title": postTitle,
+						},
+					};
+				},
+			});
+
+			const post = await prisma.post.create({
+				data: {
+					title: postTitle,
+				},
+			});
+
+			expect(post.id).toBeDefined();
+		});
+	});
 });


### PR DESCRIPTION
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>