### PR TITLE
fix: Increase test coverage and improve setup safety

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,7 @@ jobs:
         with:
           release-type: node
           package-name: release-please-action
+          token: ${{ secrets.GHA_NODEJS_TOKEN }}
       # The logic below handles the npm publication:
       - uses: actions/checkout@v2
         # these if statements ensure that a publication only occurs when

--- a/prisma/migrations/20230125135410_add_tags_model/migration.sql
+++ b/prisma/migrations/20230125135410_add_tags_model/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "Tag" (
+    "id" SERIAL NOT NULL,
+    "label" TEXT NOT NULL,
+
+    CONSTRAINT "Tag_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_PostToTag" (
+    "A" INTEGER NOT NULL,
+    "B" INTEGER NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "_PostToTag_AB_unique" ON "_PostToTag"("A", "B");
+
+-- CreateIndex
+CREATE INDEX "_PostToTag_B_index" ON "_PostToTag"("B");
+
+-- AddForeignKey
+ALTER TABLE "_PostToTag" ADD CONSTRAINT "_PostToTag_A_fkey" FOREIGN KEY ("A") REFERENCES "Post"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_PostToTag" ADD CONSTRAINT "_PostToTag_B_fkey" FOREIGN KEY ("B") REFERENCES "Tag"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,13 @@ model Post {
   title     String   @db.VarChar(255)
   author    User?    @relation(fields: [authorId], references: [id])
   authorId  Int?
+  tags      Tag[]
+}
+
+model Tag {
+  id    Int    @id @default(autoincrement())
+  label String
+  posts Post[]
 }
 
 enum Role {

--- a/test/integration/index.spec.ts
+++ b/test/integration/index.spec.ts
@@ -22,13 +22,40 @@ describe("setup", () => {
 			expect(getRoles.mock.calls).toHaveLength(1);
 			const abilities = getRoles.mock.calls[0][0];
 
-			expect(Object.keys(abilities)).toStrictEqual(["User", "Post"]);
+			expect(Object.keys(abilities)).toStrictEqual(["User", "Post", "Tag"]);
 			expect(Object.keys(abilities.User)).toStrictEqual(["create", "read", "update", "delete"]);
 			expect(Object.keys(abilities.Post)).toStrictEqual(["create", "read", "update", "delete"]);
+			expect(Object.keys(abilities.Tag)).toStrictEqual(["create", "read", "update", "delete"]);
 		});
 	});
 
 	describe("params.getContext()", () => {
+		it("should skip RBAC if .getContext() returns null", async () => {
+			const prisma = new PrismaClient();
+
+			const role = `USER_${uuid()}`;
+
+			await setup({
+				prisma,
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.Post.read],
+					};
+				},
+				getContext: () => {
+					return null;
+				},
+			});
+
+			const post = await prisma.post.create({
+				data: {
+					title: "Test post",
+				},
+			});
+
+			expect(post.id).toBeDefined();
+		});
+
 		it("should allow a custom context to be set", async () => {
 			const prisma = new PrismaClient();
 

--- a/test/integration/middleware.spec.ts
+++ b/test/integration/middleware.spec.ts
@@ -6,98 +6,96 @@ import { setup } from "../../src";
 let adminClient: PrismaClient;
 
 beforeAll(async () => {
-	adminClient = new PrismaClient();
+  adminClient = new PrismaClient();
 });
 
 describe("middlewares", () => {
-	it("should not run twice", async () => {
-		const prisma = new PrismaClient();
+  it("should not run twice", async () => {
+    const prisma = new PrismaClient();
 
-		const middlewareSpy = jest.fn(async (params, next) => {
-			return next(params);
-		});
+    const middlewareSpy = jest.fn(async (params, next) => {
+      return next(params);
+    });
 
-		prisma.$use(middlewareSpy);
+    prisma.$use(middlewareSpy);
 
-		const role = `USER_${uuid()}`;
+    const role = `USER_${uuid()}`;
 
-		await setup({
-			prisma,
-			getRoles(abilities) {
-				return {
-					[role]: [abilities.Post.read, abilities.Post.create],
-				};
-			},
-			getContext: () => {
-				return {
-					role,
-					context: {},
-				};
-			},
-		});
+    await setup({
+      prisma,
+      getRoles(abilities) {
+        return {
+          [role]: [abilities.Post.read, abilities.Post.create],
+        };
+      },
+      getContext: () => {
+        return {
+          role,
+        };
+      },
+    });
 
-		middlewareSpy.mockClear();
+    middlewareSpy.mockClear();
 
-		const post = await prisma.post.create({
-			data: {
-				title: `Test post from ${role}`,
-			},
-		});
+    const post = await prisma.post.create({
+      data: {
+        title: `Test post from ${role}`,
+      },
+    });
 
-		expect(post.id).toBeDefined();
-		expect(middlewareSpy).toHaveBeenCalledTimes(1);
-	});
+    expect(post.id).toBeDefined();
+    expect(middlewareSpy).toHaveBeenCalledTimes(1);
+  });
 
-	it("should not be able to bypass RBAC when using cls-hooked", async () => {
-		const prisma = new PrismaClient();
+  it("should not be able to bypass RBAC when using cls-hooked", async () => {
+    const prisma = new PrismaClient();
 
-		const middleware: Prisma.Middleware = async (params, next) => {
-			if (params.model === "Post") {
-				const post = await next(params);
-				return post;
-			} else {
-				return next(params);
-			}
-		};
+    const middleware: Prisma.Middleware = async (params, next) => {
+      if (params.model === "Post") {
+        const post = await next(params);
+        return post;
+      } else {
+        return next(params);
+      }
+    };
 
-		const clsSession = createNamespace("test");
+    const clsSession = createNamespace("test");
 
-		prisma.$use(middleware);
+    prisma.$use(middleware);
 
-		const roleName = `USER_${uuid()}`;
+    const roleName = `USER_${uuid()}`;
 
-		await setup({
-			prisma,
-			getRoles(abilities) {
-				return {
-					[roleName]: [abilities.Post.read],
-				};
-			},
-			getContext: () => {
-				const role = clsSession.get("role");
-				return {
-					role,
-					context: {},
-				};
-			},
-		});
+    await setup({
+      prisma,
+      getRoles(abilities) {
+        return {
+          [roleName]: [abilities.Post.read],
+        };
+      },
+      getContext: () => {
+        const role = clsSession.get("role");
+        return {
+          role,
+        };
+      },
+    });
 
-		await expect(
-			new Promise((res, reject) => {
-				clsSession.run(async () => {
-					try {
-						clsSession.set("role", roleName);
-						const result = await prisma.post.create({
-							data: {
-								title: `Test post from ${roleName}`,
-							},
-						});
-						res(result);
-					} catch (e) {
-						reject(e);
-					}
-				});
-			}),
-		).rejects.toThrow();
-	});
+    await expect(
+      new Promise((res, reject) => {
+        clsSession.run(async () => {
+          try {
+            clsSession.set("role", roleName);
+            const result = await prisma.post.create({
+              data: {
+                title: `Test post from ${roleName}`,
+              },
+            });
+            res(result);
+          } catch (e) {
+            reject(e);
+          }
+        });
+      })
+    ).rejects.toThrow();
+  });
 });

--- a/test/integration/rbac.spec.ts
+++ b/test/integration/rbac.spec.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/client";
+import { PrismaClient, User } from "@prisma/client";
 import { setup } from "../../src";
 import { v4 as uuid } from "uuid";
 
@@ -9,6 +9,36 @@ beforeAll(async () => {
 });
 
 describe("rbac", () => {
+	describe("raw", () => {
+		it("should skip RBAC when using prisma.$queryRaw()", async () => {
+			const prisma = new PrismaClient();
+
+			const user = await prisma.user.create({
+				data: {
+					email: `test-${uuid()}@test.com`,
+				},
+			});
+
+			const role = `USER_${uuid()}`;
+
+			await setup({
+				prisma,
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.Post.read],
+					};
+				},
+				getContext: () => ({
+					role,
+				}),
+			});
+
+			const users: User[] = await prisma.$queryRaw`SELECT * FROM "User" WHERE "id" = ${user.id}`;
+
+			expect(users).toHaveLength(1);
+			expect(users[0].id).toBe(user.id);
+		});
+	});
 	describe("CREATE", () => {
 		it("should be able to allow a role to create a resource", async () => {
 			const prisma = new PrismaClient();
@@ -22,12 +52,9 @@ describe("rbac", () => {
 						[role]: [abilities.Post.read, abilities.Post.create],
 					};
 				},
-				getContext: () => {
-					return {
-						role,
-						context: {},
-					};
-				},
+				getContext: () => ({
+					role,
+				}),
 			});
 
 			const post = await prisma.post.create({
@@ -51,12 +78,9 @@ describe("rbac", () => {
 						[role]: [abilities.Post.read],
 					};
 				},
-				getContext: () => {
-					return {
-						role,
-						context: {},
-					};
-				},
+				getContext: () => ({
+					role,
+				}),
 			});
 
 			await expect(
@@ -82,12 +106,9 @@ describe("rbac", () => {
 						[role]: [abilities.Post.read],
 					};
 				},
-				getContext: () => {
-					return {
-						role,
-						context: {},
-					};
-				},
+				getContext: () => ({
+					role,
+				}),
 			});
 
 			const { id: postId } = await adminClient.post.create({
@@ -115,12 +136,9 @@ describe("rbac", () => {
 						[role]: [abilities.User.read],
 					};
 				},
-				getContext: () => {
-					return {
-						role,
-						context: {},
-					};
-				},
+				getContext: () => ({
+					role,
+				}),
 			});
 
 			const { id: postId } = await adminClient.post.create({
@@ -134,6 +152,90 @@ describe("rbac", () => {
 			});
 
 			expect(post).toBeNull();
+		});
+
+		it("should be able to allow a role to read a resource using 1:1 relation queries", async () => {
+			const prisma = new PrismaClient();
+
+			const role = `USER_${uuid()}`;
+
+			await setup({
+				prisma,
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.Post.read, abilities.User.read],
+					};
+				},
+				getContext: () => ({
+					role,
+				}),
+			});
+
+			const { id: postId } = await adminClient.post.create({
+				data: {
+					title: `Test post from ${role}`,
+					author: {
+						create: {
+							email: `test-${uuid()}@test.com`,
+						},
+					},
+				},
+			});
+
+			const post = await prisma.post.findUnique({
+				where: { id: postId },
+				include: {
+					author: true,
+				},
+			});
+
+			expect(post?.id).toBe(postId);
+			expect(post?.author).toBeDefined();
+		});
+
+		it("should be able to allow a role to read a resource using many-to-many relation queries", async () => {
+			const prisma = new PrismaClient();
+
+			const role = `USER_${uuid()}`;
+
+			await setup({
+				prisma,
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.Post.read, abilities.User.read, abilities.Tag.read],
+					};
+				},
+				getContext: () => ({
+					role,
+				}),
+			});
+
+			const { id: postId } = await adminClient.post.create({
+				data: {
+					title: `Test post from ${role}`,
+					tags: {
+						create: {
+							label: "engineering",
+						},
+					},
+				},
+			});
+
+			const post = await prisma.post.findUnique({
+				where: { id: postId },
+				select: {
+					id: true,
+					title: true,
+					tags: {
+						select: {
+							label: true,
+						},
+					},
+				},
+			});
+
+			expect(post?.id).toBe(postId);
+			expect(post?.tags).toBeDefined();
 		});
 	});
 });


### PR DESCRIPTION
This change introduces the use of advisory locks on startup to ensure safety if multiple clients are bootstrapping simultaneously. Without the lock you run the risk of concurrent updates to the same tables (mostly when using `GRANT`).

Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>