### PR TITLE
feat: Add functionality for using Prisma as a query builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,22 @@
 Yates is a module for implementing role based access control with Prisma. It is designed to be used with the [Prisma Client](https://www.prisma.io/docs/reference/tools-and-interfaces/prisma-client) and [PostgreSQL](https://www.postgresql.org/).
 It uses the [Row Level Security](https://www.postgresql.org/docs/9.5/ddl-rowsecurity.html) feature of PostgreSQL to provide a simple and secure way to implement role based access control that allows you to define complex access control rules and have them apply to all of your Prisma queries automatically.
 
+## Prerequisites
+
+Yates requires the `prisma` package ate version 4.9.0 or greater and the `@prisma/client` package at version 4.0.0 or greater. Additionally it makes use of the [Prisma Client extensions](https://www.prisma.io/docs/concepts/components/prisma-client/client-extensions) preview feature to generate rules, so you will need to enable this feature in your Prisma schema.
+
+````prisma
+generator client {
+  provider        = "prisma-client-js"
+  previewFeatures = ["clientExtensions"]
+}
+```
+
 ## Installation
 
 ```bash
 npm i @cerebruminc/yates
-```
+````
 
 ## Usage
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.1.1",
       "license": "MIT",
       "dependencies": {
+        "@lucianbuzzo/node-sql-parser": "^4.6.6",
         "lodash": "^4.17.21"
       },
       "devDependencies": {
@@ -965,6 +966,17 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "node_modules/@lucianbuzzo/node-sql-parser": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/@lucianbuzzo/node-sql-parser/-/node-sql-parser-4.6.6.tgz",
+      "integrity": "sha512-bz0d38rmkw3iCjx3+ThSOqlFWtopAdAWAt/H06z9Ve5OVTt//v2c2tZLIVScSAHM5c+1/GOUWJb+hHtpHRJ7Pg==",
+      "dependencies": {
+        "big-integer": "^1.6.48"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@prisma/client": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.9.0.tgz",
@@ -1407,6 +1419,14 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
+      "engines": {
+        "node": ">=0.6"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4530,6 +4550,14 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
+    "@lucianbuzzo/node-sql-parser": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/@lucianbuzzo/node-sql-parser/-/node-sql-parser-4.6.6.tgz",
+      "integrity": "sha512-bz0d38rmkw3iCjx3+ThSOqlFWtopAdAWAt/H06z9Ve5OVTt//v2c2tZLIVScSAHM5c+1/GOUWJb+hHtpHRJ7Pg==",
+      "requires": {
+        "big-integer": "^1.6.48"
+      }
+    },
     "@prisma/client": {
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.9.0.tgz",
@@ -4880,6 +4908,11 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "big-integer": {
+      "version": "1.6.51",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
     },
     "brace-expansion": {
       "version": "1.1.11",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "uuid": "^9.0.0"
   },
   "dependencies": {
+    "@lucianbuzzo/node-sql-parser": "^4.6.6",
     "lodash": "^4.17.21"
   },
   "peerDependencies": {

--- a/prisma/migrations/20230209115623_add_item_table/migration.sql
+++ b/prisma/migrations/20230209115623_add_item_table/migration.sql
@@ -1,0 +1,9 @@
+-- CreateTable
+CREATE TABLE "Item" (
+    "id" SERIAL NOT NULL,
+    "value" DOUBLE PRECISION NOT NULL,
+    "SKU" TEXT,
+    "stock" INTEGER NOT NULL DEFAULT 0,
+
+    CONSTRAINT "Item_pkey" PRIMARY KEY ("id")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,8 +5,10 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// Note that any user of Yates will also need to use the clientExtensions preview feature
 generator client {
-  provider = "prisma-client-js"
+  provider        = "prisma-client-js"
+  previewFeatures = ["clientExtensions"]
 }
 
 model User {
@@ -27,6 +29,13 @@ model Post {
   author    User?    @relation(fields: [authorId], references: [id])
   authorId  Int?
   tags      Tag[]
+}
+
+model Item {
+  id    Int     @id @default(autoincrement())
+  value Float
+  SKU   String?
+  stock Int     @default(0)
 }
 
 model Tag {

--- a/src/escape.ts
+++ b/src/escape.ts
@@ -1,0 +1,34 @@
+// Source borrowed from node-postgrs (which borrows from PG itself)
+// https://github.com/brianc/node-postgres/blob/3f6760c62ee2a901d374b5e50c2f025b7d550315/packages/pg/lib/client.js#L408-L437
+// We need to manually escape strings because we're interpolating client values into SQL statements that don't support `PREPARE`, such as `CREATE POLICY`
+
+// Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
+export const escapeIdentifier = function (str: string) {
+	return `"${str.replace(/"/g, '""')}"`;
+};
+
+// Ported from PostgreSQL 9.2.4 source code in src/interfaces/libpq/fe-exec.c
+export const escapeLiteral = function (str: string) {
+	var hasBackslash = false;
+	var escaped = "'";
+
+	for (var i = 0; i < str.length; i++) {
+		var c = str[i];
+		if (c === "'") {
+			escaped += c + c;
+		} else if (c === "\\") {
+			escaped += c + c;
+			hasBackslash = true;
+		} else {
+			escaped += c;
+		}
+	}
+
+	escaped += "'";
+
+	if (hasBackslash === true) {
+		escaped = ` E${escaped}`;
+	}
+
+	return escaped;
+};

--- a/src/expressions.ts
+++ b/src/expressions.ts
@@ -1,0 +1,297 @@
+import { Prisma, PrismaClient } from "@prisma/client";
+import { Dictionary, get } from "lodash";
+import random from "lodash/random";
+import matches from "lodash/matches";
+import { Parser } from "@lucianbuzzo/node-sql-parser";
+import { escapeIdentifier, escapeLiteral } from "./escape";
+
+const PRISMA_NUMERIC_TYPES = ["Int", "BigInt", "Float", "Decimal"];
+
+const deepFind = (obj: any, subObj: any): any => {
+	const matcher = matches(subObj);
+	for (const key in obj) {
+		if (matcher(obj[key])) {
+			return obj[key];
+		} else if (typeof obj[key] === "object") {
+			const result = deepFind(obj[key], subObj);
+			if (result) {
+				return result;
+			}
+		}
+	}
+};
+
+type Token = {
+	astFragment: any;
+};
+type Tokens = Dictionary<Token>;
+
+export type Expression =
+	| string
+	| ((
+			client: PrismaClient,
+			// Explicitly return any, so that the prisma client doesn't error
+			row: (col: string) => any,
+			context: (key: string) => string,
+	  ) => Promise<any> | { [col: string]: any });
+
+const expressionRowName = (col: string) => `___yates_row_${col}`;
+const expressionContext = (context: string) => `___yates_context_${context}`;
+// Generate a big 32bit signed integer to use as an ID
+const getLargeRandomInt = () => random(1000000000, 2147483647);
+
+const getDmmfMetaData = (client: PrismaClient, model: string, field: string) => {
+	const modelData = (client as any)._baseDmmf.datamodel.models.find((m: any) => m.name === model);
+	if (!modelData) {
+		throw new Error(`Could not retrieve model data from Prisma Client for model '${model}'`);
+	}
+	const fieldData = modelData.fields.find((f: any) => f.name === field);
+
+	return fieldData;
+};
+
+// Perform substitution of Ints so that Prisma doesn't throw an error due to mismatched type values
+// After we've captured the SQL, we can replace the Ints with the original values
+const tokenizeWhereExpression = (
+	/** The Prisma client to use for metadata */
+	client: PrismaClient,
+	/** The Prisma where expression to be tokenized */
+	where: Dictionary<any>,
+	/** The base table we are generating an expression for */
+	table: string,
+	/** The model name being queried. e.g. 'User' */
+	model: string,
+	/** The tokens object to add the new tokens to */
+	tokens: Tokens = {},
+): {
+	tokens: Tokens;
+	where: Dictionary<any>;
+} => {
+	for (const field in where) {
+		// Get field data from the prisma client for the model and field being queried
+		const fieldData = getDmmfMetaData(client, model, field);
+		let int: number;
+
+		// Small loop to make sure we get a unique int for the token key
+		do {
+			int = getLargeRandomInt();
+		} while (tokens[int]);
+
+		let astFragment = {};
+
+		const value = where[field];
+		const isNumeric = PRISMA_NUMERIC_TYPES.includes(fieldData.type);
+		const isColumnName = typeof value === "string" && !!value.match(/^___yates_row_/);
+		const isContext = typeof value === "string" && !!value.match(/^___yates_context_/);
+
+		switch (true) {
+			case isColumnName:
+				// Substiture the yates row placeholder for the actual column name
+				const column = value.replace(/^___yates_row_/, "");
+				if (!getDmmfMetaData(client, table, column)) {
+					throw new Error(`Invalid field name "${column}"`);
+				}
+				astFragment = {
+					type: "column_ref",
+					schema: "public",
+					table: table,
+					column: column,
+				};
+				break;
+
+			case isContext && isNumeric:
+				astFragment = {
+					as: null,
+					type: "cast",
+					expr: {
+						type: "function",
+						name: "current_setting",
+						args: {
+							type: "expr_list",
+							value: [
+								{
+									type: "parameter",
+									value: escapeLiteral(value.replace(/^___yates_context_/, "")),
+								},
+							],
+						},
+					},
+					symbol: "::",
+					target: {
+						dataType: "float",
+						suffix: [],
+					},
+				};
+				break;
+
+			case isContext && !isNumeric:
+				astFragment = {
+					type: "function",
+					name: "current_setting",
+					args: {
+						type: "expr_list",
+						value: [
+							{
+								type: "parameter",
+								value: escapeLiteral(value.replace(/^___yates_context_/, "")),
+							},
+						],
+					},
+				};
+				break;
+
+			case isNumeric:
+				if (typeof value !== "number") {
+					throw new Error(
+						`Numeric fields can only be queried with numbers: querying field '${field}' with value '${value}'`,
+					);
+				}
+				astFragment = {
+					type: "number",
+					value,
+				};
+				break;
+
+			// All other types are treated as strings
+			default:
+				astFragment = {
+					type: "parameter",
+					value: escapeLiteral(value),
+				};
+				break;
+		}
+
+		tokens[int] = {
+			astFragment,
+		};
+
+		where[field] = isNumeric ? int : `${int}`;
+	}
+
+	return {
+		tokens,
+		where,
+	};
+};
+
+export const expressionToSQL = async (getExpression: Expression, table: string): Promise<string> => {
+	if (typeof getExpression === "string") {
+		return getExpression;
+	}
+
+	const baseClient = new PrismaClient({
+		log: [{ level: "query", emit: "event" }],
+	});
+
+	const tokens: Tokens = {};
+
+	// An extended client is used to capture the SQL query that is generated
+	// by the expression function, this allows us to:
+	// - tokenize the where clause, allowing for use of context and row values
+	// - ensures that only findFirst and findUnique are used
+	// - isolates the query from any other queries that may be running
+	const expressionClient = baseClient.$extends({
+		name: "expressionClient",
+		query: {
+			$allModels: {
+				$allOperations({ model, operation, args, query }) {
+					// if not findFirst or findUnique
+					if (operation !== "findFirst" && operation !== "findUnique") {
+						throw new Error('Only "findFirst" and "findUnique" are supported in client expressions');
+					}
+
+					if ("where" in args && args.where) {
+						const { where } = tokenizeWhereExpression(baseClient, args.where, table, model, tokens);
+						args.where = where;
+					}
+
+					return query(args);
+				},
+			},
+		},
+	});
+
+	const sql = await new Promise<string>(
+		// rome-ignore lint/suspicious/noAsyncPromiseExecutor: future cleanup
+		async (resolve, reject) => {
+			const rawExpression = getExpression(
+				expressionClient as any as PrismaClient,
+				expressionRowName,
+				expressionContext,
+			);
+			// If the raw expression is a promise, then this is a client subselect,
+			// as opoosed to a plain SQL expression or "where" object
+			const isSubselect = typeof rawExpression === "object" && typeof rawExpression.then === "function";
+
+			expressionClient.$on("query", (e) => {
+				try {
+					const parser = new Parser();
+					// Parse the query into an AST
+					const ast: any = parser.astify(e.query, {
+						database: "postgresql",
+					});
+
+					const params = JSON.parse(e.params);
+
+					// By default Prisma will use a parameter for the limit, for Yates, the value is always "1"
+					ast.limit = { seperator: "", value: [{ type: "number", value: 1 }] };
+
+					// Now that the SQL has been generated, we can replace the tokens with the original values
+					for (let i = 0; i < params.length; i++) {
+						let param = params[i];
+						const token = tokens[param];
+
+						if (!token) {
+							continue;
+						}
+
+						const parameterizedStatement = deepFind(ast, {
+							right: {
+								type: "origin",
+								value: `$${i + 1}`,
+							},
+						});
+
+						if (!parameterizedStatement) {
+							continue;
+						}
+
+						parameterizedStatement.right = token.astFragment;
+					}
+
+					if (isSubselect) {
+						// For subselects, we need to convert the entire query and wrap in EXISTS so it converts to a binary expression
+						const subSelect = parser.sqlify(ast, {
+							database: "postgresql",
+						});
+						resolve(`EXISTS(${subSelect})`);
+					} else {
+						// For basic expressions, we're only interested in the WHERE clause and can convert just the WHERE clause into SQL
+						const where = parser.exprToSQL(ast.where, {
+							database: "postgresql",
+						});
+
+						resolve(where);
+					}
+				} catch (error) {
+					reject(error);
+				}
+			});
+
+			try {
+				// If the raw expression is a promise, we need to wait for it to resolve
+				if (isSubselect) {
+					await rawExpression;
+				} else {
+					await (expressionClient as any)[table].findFirst({
+						where: rawExpression,
+					});
+				}
+			} catch (error) {
+				reject(error);
+			}
+		},
+	);
+
+	return sql;
+};

--- a/test/integration/expressions.spec.ts
+++ b/test/integration/expressions.spec.ts
@@ -1,0 +1,628 @@
+import { PrismaClient } from "@prisma/client";
+import _ from "lodash";
+import { v4 as uuid } from "uuid";
+import { setup } from "../../src";
+
+jest.setTimeout(30000);
+
+let adminClient: PrismaClient;
+
+beforeAll(async () => {
+	adminClient = new PrismaClient();
+});
+
+describe("expressions", () => {
+	describe("using a Prisma 'where' clause as an expression", () => {
+		it("should be able to allow access using static values", async () => {
+			const client = new PrismaClient();
+			const role = `USER_${uuid()}`;
+
+			const user = await adminClient.user.create({
+				data: {
+					email: `test-user-${uuid()}@example.com`,
+				},
+			});
+			const dummyUser = await adminClient.user.create({
+				data: {
+					email: `test-user-${uuid()}@example.com`,
+				},
+			});
+
+			await setup({
+				prisma: client,
+				customAbilities: {
+					User: {
+						readOwnUser: {
+							description: "Read own user",
+							operation: "SELECT",
+							expression: (_client: PrismaClient, _row, _context) => {
+								return {
+									id: user.id,
+								};
+							},
+						},
+					},
+				},
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.User.readOwnUser],
+					};
+				},
+				getContext: () => ({
+					role,
+					context: {},
+				}),
+			});
+
+			const notFound = await client.user.findUnique({
+				where: {
+					id: dummyUser.id,
+				},
+			});
+
+			expect(notFound).toBeNull();
+
+			const ownUser = await client.user.findUnique({
+				where: {
+					id: user.id,
+				},
+			});
+
+			expect(ownUser).toBeDefined();
+		});
+
+		it("should be able to allow access using row values", async () => {
+			const client = new PrismaClient();
+			const role = `USER_${uuid()}`;
+
+			const email = `test-user-${uuid()}@example.com`;
+
+			const user = await adminClient.user.create({
+				data: {
+					email,
+					name: email,
+				},
+			});
+
+			const dummyUser = await adminClient.user.create({
+				data: {
+					email: `test-user-${uuid()}@example.com`,
+					name: "John Matrix",
+				},
+			});
+
+			await setup({
+				prisma: client,
+				customAbilities: {
+					User: {
+						readEmailUser: {
+							description: "Read user where name is equal to email",
+							operation: "SELECT",
+							expression: (_client: PrismaClient, row, _context) => {
+								return {
+									name: row("email"),
+								};
+							},
+						},
+					},
+				},
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.User.readEmailUser],
+					};
+				},
+				getContext: () => ({
+					role,
+					context: {},
+				}),
+			});
+
+			const notFound = await client.user.findUnique({
+				where: {
+					id: dummyUser.id,
+				},
+			});
+
+			expect(notFound).toBeNull();
+
+			const ownUser = await client.user.findUnique({
+				where: {
+					id: user.id,
+				},
+			});
+
+			expect(ownUser).toBeDefined();
+		});
+
+		it("should be able to allow access using numeric context values", async () => {
+			const client = new PrismaClient();
+			const role = `USER_${uuid()}`;
+
+			const item1 = await adminClient.item.create({
+				data: {
+					value: 50,
+				},
+			});
+			const item2 = await adminClient.item.create({
+				data: {
+					value: 100,
+				},
+			});
+
+			await setup({
+				prisma: client,
+				customAbilities: {
+					Item: {
+						readWithValue: {
+							description: "Read items with specific value",
+							operation: "SELECT",
+							expression: (_client: PrismaClient, _row, context) => {
+								return {
+									value: context("item.value"),
+								};
+							},
+						},
+					},
+				},
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.Item.readWithValue],
+					};
+				},
+				getContext: () => ({
+					role,
+					context: {
+						"item.value": item1.value,
+					},
+				}),
+			});
+
+			const results = await client.item.findMany({
+				where: {
+					id: {
+						in: [item1.id, item2.id],
+					},
+				},
+			});
+
+			expect(results.length).toBe(1);
+			expect(results[0].id).toBe(item1.id);
+		});
+
+		it("should be able to allow access using textual context values", async () => {
+			const client = new PrismaClient();
+			const role = `USER_${uuid()}`;
+
+			const user = await adminClient.user.create({
+				data: {
+					email: `test-user-${uuid()}@example.com`,
+				},
+			});
+			const dummyUser = await adminClient.user.create({
+				data: {
+					email: `test-user-${uuid()}@example.com`,
+				},
+			});
+
+			await setup({
+				prisma: client,
+				customAbilities: {
+					User: {
+						readOwnEmail: {
+							description: "Read own user",
+							operation: "SELECT",
+							expression: (_client: PrismaClient, _row, context) => {
+								return {
+									email: context("user.email"),
+								};
+							},
+						},
+					},
+				},
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.User.readOwnEmail],
+					};
+				},
+				getContext: () => ({
+					role,
+					context: {
+						"user.email": user.email,
+					},
+				}),
+			});
+
+			const notFound = await client.user.findUnique({
+				where: {
+					id: dummyUser.id,
+				},
+			});
+
+			expect(notFound).toBeNull();
+
+			const ownUser = await client.user.findUnique({
+				where: {
+					id: user.id,
+				},
+			});
+
+			expect(ownUser).toBeDefined();
+		});
+
+		it("should correctly escape single quotes", async () => {
+			const client = new PrismaClient();
+			const role = `USER_${uuid()}`;
+
+			const user = await adminClient.user.create({
+				data: {
+					name: "Al'Akir",
+					email: `test-user-${uuid()}@example.com`,
+				},
+			});
+			const dummyUser = await adminClient.user.create({
+				data: {
+					email: `test-user-${uuid()}@example.com`,
+				},
+			});
+
+			await setup({
+				prisma: client,
+				customAbilities: {
+					User: {
+						singleQuoteSelect: {
+							description: "Test ability",
+							operation: "SELECT",
+							expression: () => {
+								return {
+									name: "Al'Akir",
+								};
+							},
+						},
+					},
+				},
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.User.singleQuoteSelect],
+					};
+				},
+				getContext: () => ({
+					role,
+				}),
+			});
+
+			expect(
+				await client.user.findUnique({
+					where: {
+						id: dummyUser.id,
+					},
+				}),
+			).toBeNull();
+
+			const exists = await client.user.findUnique({
+				where: {
+					id: user.id,
+				},
+			});
+
+			expect(exists).toBeDefined();
+		});
+
+		it("should not allow injection attacks on numeric types", async () => {
+			const client = new PrismaClient();
+			const role = `USER_${uuid()}`;
+
+			await expect(
+				setup({
+					prisma: client,
+					customAbilities: {
+						User: {
+							numericIdSelect: {
+								description: "Test ability",
+								operation: "SELECT",
+								expression: () => {
+									return {
+										id: "escape'--",
+									};
+								},
+							},
+						},
+					},
+					getRoles(abilities) {
+						return {
+							[role]: [abilities.User.numericIdSelect],
+						};
+					},
+					getContext: () => ({
+						role,
+					}),
+				}),
+			).rejects.toThrow("Numeric fields can only be queried with numbers");
+		});
+
+		it("should not allow injection attacks on row values", async () => {
+			const client = new PrismaClient();
+			const role = `USER_${uuid()}`;
+
+			await expect(
+				setup({
+					prisma: client,
+					customAbilities: {
+						User: {
+							columndEscapeSelect: {
+								description: "Test ability",
+								operation: "SELECT",
+								expression: (_client, row) => {
+									return {
+										name: row(`escape"--`),
+									};
+								},
+							},
+						},
+					},
+					getRoles(abilities) {
+						return {
+							[role]: [abilities.User.columndEscapeSelect],
+						};
+					},
+					getContext: () => ({
+						role,
+					}),
+				}),
+			).rejects.toThrow("Invalid field name");
+		});
+	});
+
+	describe("using a Prisma client query as an expression", () => {
+		it("should be able to allow access using static values", async () => {
+			const client = new PrismaClient();
+
+			const role = `USER_${uuid()}`;
+
+			const label = `test-label-${uuid()}`;
+
+			await setup({
+				prisma: client,
+				customAbilities: {
+					Post: {
+						customCreateAbility: {
+							description: "Read where tag label exists with a specific value",
+							operation: "INSERT",
+							// expression: "title = 'test'",
+							//expression: EXISTS(SELECT 1 FROM "Post" WHERE "Post"."title" = 'test'),
+							expression: (client: PrismaClient) => {
+								return client.tag.findFirst({
+									where: {
+										label,
+									},
+								});
+							},
+						},
+					},
+				},
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.Post.customCreateAbility, abilities.Post.read, abilities.Tag.read, abilities.Tag.create],
+					};
+				},
+				getContext: () => ({
+					role,
+					context: {
+						"tag.title": "test",
+					},
+				}),
+			});
+
+			const testTitle = `test_${uuid()}`;
+
+			await expect(
+				client.post.create({
+					data: {
+						title: testTitle,
+					},
+				}),
+			).rejects.toThrow();
+
+			await client.tag.create({
+				data: {
+					label,
+				},
+			});
+
+			const post = await client.post.create({
+				data: {
+					title: testTitle,
+				},
+			});
+
+			expect(post.id).toBeDefined();
+		});
+
+		it("should be able to allow access using textual row values", async () => {
+			const client = new PrismaClient();
+
+			const role = `USER_${uuid()}`;
+
+			await setup({
+				prisma: client,
+				customAbilities: {
+					Post: {
+						customCreateAbility: {
+							description: "Create posts where there is already a tag label with the same title",
+							operation: "INSERT",
+							expression: (client: PrismaClient, row) => {
+								return client.tag.findFirst({
+									where: {
+										label: row("title"),
+									},
+								});
+							},
+						},
+					},
+				},
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.Post.customCreateAbility, abilities.Post.read, abilities.Tag.read, abilities.Tag.create],
+					};
+				},
+				getContext: () => ({
+					role,
+					context: {},
+				}),
+			});
+
+			const testTitle = `test_${uuid()}`;
+
+			await expect(
+				client.post.create({
+					data: {
+						title: testTitle,
+					},
+				}),
+			).rejects.toThrow();
+
+			await client.tag.create({
+				data: {
+					label: testTitle,
+				},
+			});
+
+			const post = await client.post.create({
+				data: {
+					title: testTitle,
+				},
+			});
+
+			expect(post.id).toBeDefined();
+		});
+
+		it("should be able to allow access using numeric row values", async () => {
+			const client = new PrismaClient();
+
+			const role = `USER_${uuid()}`;
+
+			const testTitle = `test_${uuid()}`;
+			const post = await adminClient.post.create({
+				data: {
+					title: testTitle,
+				},
+			});
+			const item = await adminClient.item.create({
+				data: {
+					value: 9999999999,
+				},
+			});
+
+			await setup({
+				prisma: client,
+				customAbilities: {
+					Post: {
+						customValueReadAbility: {
+							description: "Read posts where there is an item with the same value as the post id",
+							operation: "SELECT",
+							expression: (client: PrismaClient, row) => {
+								return client.item.findFirst({
+									where: {
+										id: item.id,
+										value: row("id"),
+									},
+								});
+							},
+						},
+					},
+				},
+				getRoles(abilities) {
+					return {
+						[role]: [
+							abilities.Post.customValueReadAbility,
+							abilities.Item.read,
+							abilities.Tag.read,
+							abilities.Tag.create,
+						],
+					};
+				},
+				getContext: () => ({
+					role,
+					context: {},
+				}),
+			});
+
+			await expect(client.post.findFirstOrThrow({ where: { id: post.id } })).rejects.toThrow();
+
+			await adminClient.item.update({
+				where: {
+					id: item.id,
+				},
+				data: {
+					value: {
+						set: post.id,
+					},
+				},
+			});
+
+			const foundPost = await client.post.findFirstOrThrow({
+				where: { id: post.id },
+			});
+
+			expect(foundPost.id).toBeDefined();
+		});
+		it("should be able to allow access using a textual context value", async () => {
+			const client = new PrismaClient();
+
+			const role = `USER_${uuid()}`;
+
+			const testTitle = `test_${uuid()}`;
+
+			await setup({
+				prisma: client,
+				customAbilities: {
+					Post: {
+						customCreateAbility: {
+							description: "Create posts where there is already a tag label with the same title",
+							operation: "INSERT",
+							expression: (client: PrismaClient, _row, context) => {
+								return client.tag.findFirst({
+									where: {
+										label: context("post.title"),
+									},
+								});
+							},
+						},
+					},
+				},
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.Post.customCreateAbility, abilities.Post.read, abilities.Tag.read, abilities.Tag.create],
+					};
+				},
+				getContext: () => ({
+					role,
+					context: {
+						"post.title": testTitle,
+					},
+				}),
+			});
+
+			await expect(
+				client.post.create({
+					data: {
+						title: testTitle,
+					},
+				}),
+			).rejects.toThrow();
+
+			await client.tag.create({
+				data: {
+					label: testTitle,
+				},
+			});
+
+			const post = await client.post.create({
+				data: {
+					title: testTitle,
+				},
+			});
+
+			expect(post.id).toBeDefined();
+		});
+	});
+});

--- a/test/integration/index.spec.ts
+++ b/test/integration/index.spec.ts
@@ -5,322 +5,352 @@ import { setup } from "../../src";
 let adminClient: PrismaClient;
 
 beforeAll(async () => {
-	adminClient = new PrismaClient();
+  adminClient = new PrismaClient();
 });
 
 describe("setup", () => {
-	describe("params.getRoles()", () => {
-		it("should provide a set of built-in abilities for CRUD operations", async () => {
-			const prisma = new PrismaClient();
+  describe("params.getRoles()", () => {
+    it("should provide a set of built-in abilities for CRUD operations", async () => {
+      const prisma = new PrismaClient();
 
-			const getRoles = jest.fn((_abilities) => {
-				return {
-					USER: "*",
-				} as any;
-			});
+      const getRoles = jest.fn((_abilities) => {
+        return {
+          USER: "*",
+        } as any;
+      });
 
-			await setup({
-				prisma,
-				getRoles,
-				getContext: () => null,
-			});
+      await setup({
+        prisma,
+        getRoles,
+        getContext: () => null,
+      });
 
-			expect(getRoles.mock.calls).toHaveLength(1);
-			const abilities = getRoles.mock.calls[0][0];
+      expect(getRoles.mock.calls).toHaveLength(1);
+      const abilities = getRoles.mock.calls[0][0];
 
-			expect(Object.keys(abilities)).toStrictEqual(["User", "Post", "Tag"]);
-			expect(Object.keys(abilities.User)).toStrictEqual(["create", "read", "update", "delete"]);
-			expect(Object.keys(abilities.Post)).toStrictEqual(["create", "read", "update", "delete"]);
-			expect(Object.keys(abilities.Tag)).toStrictEqual(["create", "read", "update", "delete"]);
-		});
-	});
+      expect(Object.keys(abilities)).toStrictEqual([
+        "User",
+        "Post",
+        "Item",
+        "Tag",
+      ]);
+      expect(Object.keys(abilities.User)).toStrictEqual([
+        "create",
+        "read",
+        "update",
+        "delete",
+      ]);
+      expect(Object.keys(abilities.Post)).toStrictEqual([
+        "create",
+        "read",
+        "update",
+        "delete",
+      ]);
+      expect(Object.keys(abilities.Item)).toStrictEqual([
+        "create",
+        "read",
+        "update",
+        "delete",
+      ]);
+      expect(Object.keys(abilities.Tag)).toStrictEqual([
+        "create",
+        "read",
+        "update",
+        "delete",
+      ]);
+    });
+  });
 
-	describe("params.getContext()", () => {
-		it("should skip RBAC if .getContext() returns null", async () => {
-			const prisma = new PrismaClient();
+  describe("params.getContext()", () => {
+    it("should skip RBAC if .getContext() returns null", async () => {
+      const prisma = new PrismaClient();
 
-			const role = `USER_${uuid()}`;
+      const role = `USER_${uuid()}`;
 
-			await setup({
-				prisma,
-				getRoles(abilities) {
-					return {
-						[role]: [abilities.Post.read],
-					};
-				},
-				getContext: () => {
-					return null;
-				},
-			});
+      await setup({
+        prisma,
+        getRoles(abilities) {
+          return {
+            [role]: [abilities.Post.read],
+          };
+        },
+        getContext: () => {
+          return null;
+        },
+      });
 
-			const post = await prisma.post.create({
-				data: {
-					title: "Test post",
-				},
-			});
+      const post = await prisma.post.create({
+        data: {
+          title: "Test post",
+        },
+      });
 
-			expect(post.id).toBeDefined();
-		});
+      expect(post.id).toBeDefined();
+    });
 
-		it("should allow a custom context to be set", async () => {
-			const prisma = new PrismaClient();
+    it("should allow a custom context to be set", async () => {
+      const prisma = new PrismaClient();
 
-			const role = `USER_${uuid()}`;
+      const role = `USER_${uuid()}`;
 
-			const postTitle = `Test post from ${role}`;
+      const postTitle = `Test post from ${role}`;
 
-			await setup({
-				prisma,
-				customAbilities: {
-					Post: {
-						createWithTitle: {
-							description: "Test Post Create",
-							operation: "INSERT",
-							expression: "current_setting('post.title') = title",
-						},
-						readWithTitle: {
-							description: "Test Post Read",
-							operation: "SELECT",
-							expression: "current_setting('post.title') = title",
-						},
-					},
-				},
-				getRoles(abilities) {
-					return {
-						[role]: [abilities.Post.createWithTitle, abilities.Post.readWithTitle],
-					};
-				},
-				getContext: () => {
-					return {
-						role,
-						context: {
-							"post.title": postTitle,
-						},
-					};
-				},
-			});
+      await setup({
+        prisma,
+        customAbilities: {
+          Post: {
+            createWithTitle: {
+              description: "Test Post Create",
+              operation: "INSERT",
+              expression: "current_setting('post.title') = title",
+            },
+            readWithTitle: {
+              description: "Test Post Read",
+              operation: "SELECT",
+              expression: "current_setting('post.title') = title",
+            },
+          },
+        },
+        getRoles(abilities) {
+          return {
+            [role]: [
+              abilities.Post.createWithTitle,
+              abilities.Post.readWithTitle,
+            ],
+          };
+        },
+        getContext: () => {
+          return {
+            role,
+            context: {
+              "post.title": postTitle,
+            },
+          };
+        },
+      });
 
-			const post = await prisma.post.create({
-				data: {
-					title: postTitle,
-				},
-			});
+      const post = await prisma.post.create({
+        data: {
+          title: postTitle,
+        },
+      });
 
-			expect(post.id).toBeDefined();
-		});
-	});
+      expect(post.id).toBeDefined();
+    });
+  });
 
-	describe("params.customAbilities", () => {
-		it("should be able to allow a role to create a resource using a custom ability", async () => {
-			const prisma = new PrismaClient();
+  describe("params.customAbilities", () => {
+    it("should be able to allow a role to create a resource using a custom ability", async () => {
+      const prisma = new PrismaClient();
 
-			const role = `USER_${uuid()}`;
+      const role = `USER_${uuid()}`;
 
-			await setup({
-				prisma,
-				customAbilities: {
-					Post: {
-						customCreateAbility: {
-							description: "Create posts with the title 'test'",
-							operation: "INSERT",
-							expression: "title = 'test'",
-						},
-					},
-				},
-				getRoles(abilities) {
-					return {
-						[role]: [abilities.Post.customCreateAbility, abilities.Post.read],
-					};
-				},
-				getContext: () => ({
-					role,
-				}),
-			});
+      await setup({
+        prisma,
+        customAbilities: {
+          Post: {
+            customCreateAbility: {
+              description: "Create posts with the title 'test'",
+              operation: "INSERT",
+              expression: "title = 'test'",
+            },
+          },
+        },
+        getRoles(abilities) {
+          return {
+            [role]: [abilities.Post.customCreateAbility, abilities.Post.read],
+          };
+        },
+        getContext: () => ({
+          role,
+        }),
+      });
 
-			const post = await prisma.post.create({
-				data: {
-					title: "test",
-				},
-			});
+      const post = await prisma.post.create({
+        data: {
+          title: "test",
+        },
+      });
 
-			expect(post.id).toBeDefined();
+      expect(post.id).toBeDefined();
 
-			await expect(
-				prisma.post.create({
-					data: {
-						title: "invalid title",
-					},
-				}),
-			).rejects.toThrow();
-		});
+      await expect(
+        prisma.post.create({
+          data: {
+            title: "invalid title",
+          },
+        })
+      ).rejects.toThrow();
+    });
 
-		it("should be able to allow a role to read a resource using a custom ability", async () => {
-			const prisma = new PrismaClient();
+    it("should be able to allow a role to read a resource using a custom ability", async () => {
+      const prisma = new PrismaClient();
 
-			const role = `USER_${uuid()}`;
+      const role = `USER_${uuid()}`;
+      const ability = `customReadAbility_${role}`;
 
-			await setup({
-				prisma,
-				customAbilities: {
-					Post: {
-						customReadAbility: {
-							description: "Read posts with the title 'test'",
-							operation: "SELECT",
-							expression: "title = 'test'",
-						},
-					},
-				},
-				getRoles(abilities) {
-					return {
-						[role]: [abilities.Post.customReadAbility],
-					};
-				},
-				getContext: () => ({
-					role,
-				}),
-			});
+      await setup({
+        prisma,
+        customAbilities: {
+          Post: {
+            [ability]: {
+              description: "Read posts with the title 'test'",
+              operation: "SELECT",
+              expression: "title = 'test'",
+            },
+          },
+        },
+        getRoles(abilities) {
+          return {
+            [role]: [abilities.Post[ability]],
+          };
+        },
+        getContext: () => ({
+          role,
+        }),
+      });
 
-			const { id: postId } = await adminClient.post.create({
-				data: {
-					title: "test",
-				},
-			});
+      const { id: postId } = await adminClient.post.create({
+        data: {
+          title: "test",
+        },
+      });
 
-			const post = await prisma.post.findUnique({
-				where: {
-					id: postId,
-				},
-			});
+      const post = await prisma.post.findUnique({
+        where: {
+          id: postId,
+        },
+      });
 
-			expect(post).toBeDefined();
-		});
+      expect(post).toBeDefined();
+    });
 
-		it("should be able to allow a role to update a resource using a custom ability", async () => {
-			const prisma = new PrismaClient();
+    it("should be able to allow a role to update a resource using a custom ability", async () => {
+      const prisma = new PrismaClient();
 
-			const role = `USER_${uuid()}`;
+      const role = `USER_${uuid()}`;
 
-			await setup({
-				prisma,
-				customAbilities: {
-					Post: {
-						customUpdateAbility: {
-							description: "Update posts with the title 'test'",
-							operation: "UPDATE",
-							expression: "title = 'test'",
-						},
-					},
-				},
-				getRoles(abilities) {
-					return {
-						[role]: [abilities.Post.customUpdateAbility, abilities.Post.read],
-					};
-				},
-				getContext: () => ({
-					role,
-				}),
-			});
+      await setup({
+        prisma,
+        customAbilities: {
+          Post: {
+            customUpdateAbility: {
+              description: "Update posts with the title 'test'",
+              operation: "UPDATE",
+              expression: "title = 'test'",
+            },
+          },
+        },
+        getRoles(abilities) {
+          return {
+            [role]: [abilities.Post.customUpdateAbility, abilities.Post.read],
+          };
+        },
+        getContext: () => ({
+          role,
+        }),
+      });
 
-			const { id: postId } = await adminClient.post.create({
-				data: {
-					title: "test",
-				},
-			});
+      const { id: postId } = await adminClient.post.create({
+        data: {
+          title: "test",
+        },
+      });
 
-			const post = await prisma.post.update({
-				where: {
-					id: postId,
-				},
-				data: {
-					published: true,
-				},
-			});
+      const post = await prisma.post.update({
+        where: {
+          id: postId,
+        },
+        data: {
+          published: true,
+        },
+      });
 
-			expect(post.published).toBe(true);
+      expect(post.published).toBe(true);
 
-			const { id: postId2 } = await adminClient.post.create({
-				data: {
-					title: "wrong title",
-				},
-			});
+      const { id: postId2 } = await adminClient.post.create({
+        data: {
+          title: "wrong title",
+        },
+      });
 
-			const post2 = await prisma.post.update({
-				where: {
-					id: postId2,
-				},
-				data: {
-					published: true,
-				},
-			});
+      const post2 = await prisma.post.update({
+        where: {
+          id: postId2,
+        },
+        data: {
+          published: true,
+        },
+      });
 
-			expect(post2.published).toBe(false);
-		});
+      expect(post2.published).toBe(false);
+    });
 
-		it("should be able to allow a role to delete a resource using a custom ability", async () => {
-			const prisma = new PrismaClient();
+    it("should be able to allow a role to delete a resource using a custom ability", async () => {
+      const prisma = new PrismaClient();
 
-			const role = `USER_${uuid()}`;
+      const role = `USER_${uuid()}`;
 
-			await setup({
-				prisma,
-				customAbilities: {
-					Post: {
-						customDeleteAbility: {
-							description: "Delete posts with the title 'test'",
-							operation: "DELETE",
-							expression: "title = 'test'",
-						},
-					},
-				},
-				getRoles(abilities) {
-					return {
-						[role]: [abilities.Post.customDeleteAbility, abilities.Post.read],
-					};
-				},
-				getContext: () => ({
-					role,
-				}),
-			});
+      await setup({
+        prisma,
+        customAbilities: {
+          Post: {
+            customDeleteAbility: {
+              description: "Delete posts with the title 'test'",
+              operation: "DELETE",
+              expression: "title = 'test'",
+            },
+          },
+        },
+        getRoles(abilities) {
+          return {
+            [role]: [abilities.Post.customDeleteAbility, abilities.Post.read],
+          };
+        },
+        getContext: () => ({
+          role,
+        }),
+      });
 
-			const { id: postId } = await adminClient.post.create({
-				data: {
-					title: "test",
-				},
-			});
+      const { id: postId } = await adminClient.post.create({
+        data: {
+          title: "test",
+        },
+      });
 
-			await prisma.post.delete({
-				where: {
-					id: postId,
-				},
-			});
+      await prisma.post.delete({
+        where: {
+          id: postId,
+        },
+      });
 
-			const exists = await adminClient.post.findUnique({
-				where: {
-					id: postId,
-				},
-			});
+      const exists = await adminClient.post.findUnique({
+        where: {
+          id: postId,
+        },
+      });
 
-			expect(exists).toBeNull();
+      expect(exists).toBeNull();
 
-			const { id: postId2 } = await adminClient.post.create({
-				data: {
-					title: "wrong title",
-				},
-			});
+      const { id: postId2 } = await adminClient.post.create({
+        data: {
+          title: "wrong title",
+        },
+      });
 
-			await prisma.post.delete({
-				where: {
-					id: postId2,
-				},
-			});
+      await prisma.post.delete({
+        where: {
+          id: postId2,
+        },
+      });
 
-			const exists2 = await adminClient.post.findUnique({
-				where: {
-					id: postId2,
-				},
-			});
+      const exists2 = await adminClient.post.findUnique({
+        where: {
+          id: postId2,
+        },
+      });
 
-			expect(exists2).not.toBeNull();
-		});
-	});
+      expect(exists2).not.toBeNull();
+    });
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "strict": true,
     "useUnknownInCatchVariables": false,
     "noUnusedParameters": true,
-    "declaration": true
+    "declaration": true,
+    "downlevelIteration": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
Ability expressions can now be defined using a function, that returns
either a Prisma "where" clause as an object, or a Prisma client
`findFirst` or `findUnique` query. Context or row values can be
interpolated using the `row` and `context` arguments passed to the
function.

```ts
const userAbilities = {
  Post: {
    insertOwnPost: {
        description: "Insert own post",
        // You can express the rule as a Prisma `where` clause.
        expression: (client, row, context) => {
          return {
            // This expression uses a context setting returned by the getContext function
            authorId: context('user.id')
          }
        },
        operation: "INSERT",
    },
  },
  Comment: {
      deleteOnOwnPost: {
          description: "Delete comment on own post",
          // You can also express the rule as a conventional Prisma query.
          expression: (client, row, context) => {
            return client.post.findFirst({
              where: {
                id: row('postId'),
                authorId: context('user.id')
              }
            })
          },
          operation: "DELETE",
      },
  }
}
```

Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>