### PR TITLE
fix: improve abilities typings

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "trailingComma": "all",
+  "tabs": true,
+  "semi": true,
+  "singleQuote": false,
+  "printWidth": 120,
+	"useTabs": true
+}

--- a/test/integration/sanitation.spec.ts
+++ b/test/integration/sanitation.spec.ts
@@ -144,7 +144,7 @@ describe("sanitation", () => {
 
 		const postTitle = `Test post from ${role}`;
 
-		const config: SetupParams = {
+		await setup({
 			prisma,
 			customAbilities: {
 				Post: {
@@ -168,9 +168,7 @@ describe("sanitation", () => {
 					},
 				};
 			},
-		};
-
-		await setup(config);
+		});
 
 		await expect(
 			prisma.post.create({
@@ -188,7 +186,7 @@ describe("sanitation", () => {
 
 		const postTitle = `Test post from ${role}`;
 
-		const config: SetupParams = {
+		await setup({
 			prisma,
 			customAbilities: {
 				Post: {
@@ -212,9 +210,7 @@ describe("sanitation", () => {
 					},
 				};
 			},
-		};
-
-		await setup(config);
+		});
 
 		// We use a prepared statement to sanitize the value, so the expectation
 		// is that it would simply not match and fail the RLS check, rather than throwing an error
@@ -235,7 +231,7 @@ describe("sanitation", () => {
 
 		const role = `USER_${uuid()}`;
 
-		const config: SetupParams = {
+		const setupPromise = setup({
 			prisma,
 			customAbilities: {
 				Post: {
@@ -259,8 +255,7 @@ describe("sanitation", () => {
 					},
 				};
 			},
-		};
-
-		await expect(setup(config)).rejects.toThrow("syntax error");
+		});
+		await expect(setupPromise).rejects.toThrow("syntax error");
 	});
 });


### PR DESCRIPTION
This PR add proper types for custom abilities to make `getRoles` typesafe. 

![Screenshot 2023-01-27 at 10 01 26 PM](https://user-images.githubusercontent.com/6604146/215406217-7c081397-fda0-4203-bbfa-74ab12296464.png)
