### PR TITLE
fix: Don't run integration tests when a PR is closed

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@ name: Integration testing
 
 on:
   pull_request:
-    types: [opened, synchronize, closed]
+    types: [opened, synchronize]
 
 jobs:
   docker_test:


### PR DESCRIPTION
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>