### PR TITLE
fix: Explicity disconnect expression Prisma client

### DIFF
--- a/src/expressions.ts
+++ b/src/expressions.ts
@@ -293,5 +293,9 @@ export const expressionToSQL = async (getExpression: Expression, table: string):
 		},
 	);
 
+	// Close the client
+	await expressionClient.$disconnect();
+	await baseClient.$disconnect();
+
 	return sql;
 };


### PR DESCRIPTION
By default, a Prisma client will only disconnect when the Node.js process ends. When we generate RLS expressions, we only need to keep the client available for the duration of the expression calculation and it can be disconnected and disposed of afterwards.

See https://www.prisma.io/docs/concepts/components/prisma-client/working-with-prismaclient/connection-management