### PR TITLE
fix: Strongly type context values in expressions

### DIFF
--- a/src/expressions.ts
+++ b/src/expressions.ts
@@ -26,13 +26,13 @@ type Token = {
 };
 type Tokens = Dictionary<Token>;
 
-export type Expression =
+export type Expression<ContextKeys extends string = string> =
 	| string
 	| ((
 			client: PrismaClient,
 			// Explicitly return any, so that the prisma client doesn't error
 			row: (col: string) => any,
-			context: (key: string) => string,
+			context: (key: ContextKeys) => string,
 	  ) => Promise<any> | { [col: string]: any });
 
 const expressionRowName = (col: string) => `___yates_row_${col}`;


### PR DESCRIPTION
Context values used in the expression `context()` function are now strongly typed and must match the context values set with the `getContext()` function.