### PR TITLE
fix: correctly handle long ability names

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -36,8 +36,27 @@ jobs:
       - name: Bump package.json
         run: |
           npm --no-git-tag-version version $(npm show . version)-beta.dangerous.$(git rev-parse --short HEAD)
+          echo "BETA_PACKAGE_VERSION=$(npm show . version)-beta.dangerous.$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+
       # Publish version to npm
       - name: Publish beta package
         run: npm publish --tag beta
         env:
           NODE_AUTH_TOKEN: ${{ secrets.CEREBRUM_PUBLISH_NPM_TOKEN }}
+
+      # Add comment to PR with beta package version
+      - name: Find comment
+        uses: peter-evans/find-comment@v1
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: "Published beta package version:"
+          direction: first
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v1
+        if: steps.fc.outputs.comment-id == ''
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Published beta package version: `${{ env.BETA_PACKAGE_VERSION }}`

--- a/test/integration/abilities.spec.ts
+++ b/test/integration/abilities.spec.ts
@@ -1,0 +1,90 @@
+import { PrismaClient } from "@prisma/client";
+import _ from "lodash";
+import { v4 as uuid } from "uuid";
+import { setup } from "../../src";
+
+jest.setTimeout(30000);
+
+let adminClient: PrismaClient;
+
+beforeAll(async () => {
+	adminClient = new PrismaClient();
+});
+
+describe("abilities", () => {
+	it("should be able to handle long ability names", async () => {
+		const initial = new PrismaClient();
+		const role = `USER_${uuid()}`;
+
+		const mail = `test-user-${uuid()}@example.com`;
+
+		const dummyUser = await adminClient.user.create({
+			data: {
+				email: `test-user-${uuid()}@example.com`,
+			},
+		});
+
+		const longAbilityName =
+			"thisIsAnIncrediblyLongAbilityNameDesignedToTestTheSixtyThreeByteLimitOnRoleNamesInPostgres";
+
+		const readAbility = `CAN_${longAbilityName}_USER_READ`;
+		const writeAbility = `CAN_${longAbilityName}_USER_WRITE`;
+
+		const client = await setup({
+			prisma: initial,
+			customAbilities: {
+				User: {
+					[readAbility]: {
+						description: "Read",
+						operation: "SELECT",
+						expression: (_client, _row, _context) => {
+							return {
+								email: mail,
+							};
+						},
+					},
+					[writeAbility]: {
+						description: "Write",
+						operation: "INSERT",
+						expression: (_client, _row, _context) => {
+							return {
+								email: mail,
+							};
+						},
+					},
+				},
+			},
+			getRoles(abilities) {
+				return {
+					[role]: [abilities.User[readAbility], abilities.User[writeAbility]],
+				};
+			},
+			getContext: () => ({
+				role,
+				context: {},
+			}),
+		});
+
+		const notFound = await client.user.findUnique({
+			where: {
+				id: dummyUser.id,
+			},
+		});
+
+		expect(notFound).toBeNull();
+
+		const user = await client.user.create({
+			data: {
+				email: mail,
+			},
+		});
+
+		const ownUser = await client.user.findUnique({
+			where: {
+				id: user.id,
+			},
+		});
+
+		expect(ownUser).toBeDefined();
+	});
+});

--- a/test/integration/expressions.spec.ts
+++ b/test/integration/expressions.spec.ts
@@ -1,5 +1,5 @@
 import { PrismaClient } from "@prisma/client";
-import _, { initial } from "lodash";
+import _ from "lodash";
 import { v4 as uuid } from "uuid";
 import { setup } from "../../src";
 


### PR DESCRIPTION
This change restricts role names to 63 bytes, which is important to prevent ambiguity when managing role names.

In PostgreSQL, the maximum length for a role (user) name is 63 bytes. This limitation is derived from the value of the NAMEDATALEN configuration parameter, which is set to 64 bytes by default.
One byte is reserved for the null-terminator, leaving 63 bytes for the actual role name.

Keep in mind that if you use multi-byte characters in the role name, the actual number of characters may be less than 63, as each multi-byte character will consume more than one byte.