### PR TITLE
fix: Increase max wait time to 30s (from default 2s)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -143,6 +143,7 @@ export const createClient = (prisma: PrismaClient, getContext: GetContextFn) => 
 								return result;
 							},
 							{
+								maxWait: 30000,
 								timeout: 30000,
 							},
 						);


### PR DESCRIPTION
This increases the amount of time that Prisma will wait to acquire a transaction from the database to 30s. By default, Postgres will wait indefinitely (same with RDS), so increasing to 30s is fairly sane.

See https://www.prisma.io/docs/concepts/components/prisma-client/transactions#interactive-transactions