### PR TITLE
feat!: bac-329 update to prisma v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,22 +13,22 @@
         "lodash": "^4.17.21"
       },
       "devDependencies": {
-        "@prisma/client": "^4.0.0",
+        "@prisma/client": "^5.0.0",
         "@types/cls-hooked": "^4.3.3",
         "@types/jest": "^29.2.6",
         "@types/lodash": "^4.14.191",
         "@types/uuid": "^9.0.0",
         "cls-hooked": "^4.2.2",
         "jest": "^29.3.1",
-        "prisma": "^4.9.0",
+        "prisma": "^5.0.0",
         "rome": "^11.0.0",
         "ts-jest": "^29.0.5",
         "typescript": "^4.9.4",
         "uuid": "^9.0.0"
       },
       "peerDependencies": {
-        "@prisma/client": "^4.0.0",
-        "prisma": "^4.9.0"
+        "@prisma/client": "^5.0.0",
+        "prisma": "^5.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -978,16 +978,16 @@
       }
     },
     "node_modules/@prisma/client": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.12.0.tgz",
-      "integrity": "sha512-j9/ighfWwux97J2dS15nqhl60tYoH8V0IuSsgZDb6bCFcQD3fXbXmxjYC8GHhIgOk3lB7Pq+8CwElz2MiDpsSg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.1.0.tgz",
+      "integrity": "sha512-aIxuXlH3p3Vy91buodQhYgAD9m0yuxJzpXMhc1ejQ/WN3pNNWzBA0iDcBObLq8DMdszcXmoLAk3hiRq/ZwBsOw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "4.12.0-67.659ef412370fa3b41cd7bf6e94587c1dfb7f67e7"
+        "@prisma/engines-version": "5.1.0-28.a9b7003df90aa623086e4d6f4e43c72468e6339b"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.13"
       },
       "peerDependencies": {
         "prisma": "*"
@@ -999,16 +999,16 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.12.0.tgz",
-      "integrity": "sha512-0alKtnxhNB5hYU+ymESBlGI4b9XrGGSdv7Ud+8TE/fBNOEhIud0XQsAR+TrvUZgS4na5czubiMsODw0TUrgkIA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.1.0.tgz",
+      "integrity": "sha512-HqaFsnPmZOdMWkPq6tT2eTVTQyaAXEDdKszcZ4yc7DGMBIYRP6j/zAJTtZUG9SsMV8FaucdL5vRyxY/p5Ni28g==",
       "dev": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "4.12.0-67.659ef412370fa3b41cd7bf6e94587c1dfb7f67e7",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.12.0-67.659ef412370fa3b41cd7bf6e94587c1dfb7f67e7.tgz",
-      "integrity": "sha512-JIHNj5jlXb9mcaJwakM0vpgRYJIAurxTUqM0iX0tfEQA5XLZ9ONkIckkhuAKdAzocZ+80GYg7QSsfpjg7OxbOA==",
+      "version": "5.1.0-28.a9b7003df90aa623086e4d6f4e43c72468e6339b",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.1.0-28.a9b7003df90aa623086e4d6f4e43c72468e6339b.tgz",
+      "integrity": "sha512-jTwE2oy1yjICmTfnCR0ASIpuMZXZ18sUzQXB7V0RMbrM9OlcmbUwXPuYhnxXuWN8XwRmujeIhsXs/Zeh+fjPOQ==",
       "dev": true
     },
     "node_modules/@rometools/cli-darwin-arm64": {
@@ -1566,9 +1566,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
-      "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
       "dev": true,
       "funding": [
         {
@@ -3205,20 +3205,19 @@
       }
     },
     "node_modules/prisma": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.12.0.tgz",
-      "integrity": "sha512-xqVper4mbwl32BWzLpdznHAYvYDWQQWK2tBfXjdUD397XaveRyAP7SkBZ6kFlIg8kKayF4hvuaVtYwXd9BodAg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.1.0.tgz",
+      "integrity": "sha512-wkXvh+6wxk03G8qwpZMOed4Y3j+EQ+bMTlvbDZHeal6k1E8QuGKzRO7DRXlE1NV0WNgOAas8kwZqcLETQ2+BiQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "4.12.0"
+        "@prisma/engines": "5.1.0"
       },
       "bin": {
-        "prisma": "build/index.js",
-        "prisma2": "build/index.js"
+        "prisma": "build/index.js"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.13"
       }
     },
     "node_modules/prompts": {
@@ -3266,12 +3265,12 @@
       }
     },
     "node_modules/resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -4577,24 +4576,24 @@
       }
     },
     "@prisma/client": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-4.12.0.tgz",
-      "integrity": "sha512-j9/ighfWwux97J2dS15nqhl60tYoH8V0IuSsgZDb6bCFcQD3fXbXmxjYC8GHhIgOk3lB7Pq+8CwElz2MiDpsSg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.1.0.tgz",
+      "integrity": "sha512-aIxuXlH3p3Vy91buodQhYgAD9m0yuxJzpXMhc1ejQ/WN3pNNWzBA0iDcBObLq8DMdszcXmoLAk3hiRq/ZwBsOw==",
       "dev": true,
       "requires": {
-        "@prisma/engines-version": "4.12.0-67.659ef412370fa3b41cd7bf6e94587c1dfb7f67e7"
+        "@prisma/engines-version": "5.1.0-28.a9b7003df90aa623086e4d6f4e43c72468e6339b"
       }
     },
     "@prisma/engines": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-4.12.0.tgz",
-      "integrity": "sha512-0alKtnxhNB5hYU+ymESBlGI4b9XrGGSdv7Ud+8TE/fBNOEhIud0XQsAR+TrvUZgS4na5czubiMsODw0TUrgkIA==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.1.0.tgz",
+      "integrity": "sha512-HqaFsnPmZOdMWkPq6tT2eTVTQyaAXEDdKszcZ4yc7DGMBIYRP6j/zAJTtZUG9SsMV8FaucdL5vRyxY/p5Ni28g==",
       "dev": true
     },
     "@prisma/engines-version": {
-      "version": "4.12.0-67.659ef412370fa3b41cd7bf6e94587c1dfb7f67e7",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-4.12.0-67.659ef412370fa3b41cd7bf6e94587c1dfb7f67e7.tgz",
-      "integrity": "sha512-JIHNj5jlXb9mcaJwakM0vpgRYJIAurxTUqM0iX0tfEQA5XLZ9ONkIckkhuAKdAzocZ+80GYg7QSsfpjg7OxbOA==",
+      "version": "5.1.0-28.a9b7003df90aa623086e4d6f4e43c72468e6339b",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.1.0-28.a9b7003df90aa623086e4d6f4e43c72468e6339b.tgz",
+      "integrity": "sha512-jTwE2oy1yjICmTfnCR0ASIpuMZXZ18sUzQXB7V0RMbrM9OlcmbUwXPuYhnxXuWN8XwRmujeIhsXs/Zeh+fjPOQ==",
       "dev": true
     },
     "@rometools/cli-darwin-arm64": {
@@ -5024,9 +5023,9 @@
       "dev": true
     },
     "ci-info": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
-      "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
+      "integrity": "sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==",
       "dev": true
     },
     "cjs-module-lexer": {
@@ -6260,12 +6259,12 @@
       }
     },
     "prisma": {
-      "version": "4.12.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-4.12.0.tgz",
-      "integrity": "sha512-xqVper4mbwl32BWzLpdznHAYvYDWQQWK2tBfXjdUD397XaveRyAP7SkBZ6kFlIg8kKayF4hvuaVtYwXd9BodAg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.1.0.tgz",
+      "integrity": "sha512-wkXvh+6wxk03G8qwpZMOed4Y3j+EQ+bMTlvbDZHeal6k1E8QuGKzRO7DRXlE1NV0WNgOAas8kwZqcLETQ2+BiQ==",
       "dev": true,
       "requires": {
-        "@prisma/engines": "4.12.0"
+        "@prisma/engines": "5.1.0"
       }
     },
     "prompts": {
@@ -6297,12 +6296,12 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.22.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
-      "integrity": "sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==",
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
       "dev": true,
       "requires": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.11.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
   "author": "Cerebrum <hello@cerebrum.com> (https://cerebrum.com)",
   "license": "MIT",
   "devDependencies": {
-    "@prisma/client": "^4.0.0",
+    "@prisma/client": "^5.0.0",
     "@types/cls-hooked": "^4.3.3",
     "@types/jest": "^29.2.6",
     "@types/lodash": "^4.14.191",
     "@types/uuid": "^9.0.0",
     "cls-hooked": "^4.2.2",
     "jest": "^29.3.1",
-    "prisma": "^4.9.0",
+    "prisma": "^5.0.0",
     "rome": "^11.0.0",
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.4",
@@ -33,7 +33,7 @@
     "lodash": "^4.17.21"
   },
   "peerDependencies": {
-    "@prisma/client": "^4.0.0",
-    "prisma": "^4.9.0"
+    "@prisma/client": "^5.0.0",
+    "prisma": "^5.0.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,8 +7,7 @@ datasource db {
 
 // Note that any user of Yates will also need to use the clientExtensions preview feature
 generator client {
-  provider        = "prisma-client-js"
-  previewFeatures = ["clientExtensions"]
+  provider = "prisma-client-js"
 }
 
 model User {

--- a/test/integration/expressions.spec.ts
+++ b/test/integration/expressions.spec.ts
@@ -368,7 +368,7 @@ describe("expressions", () => {
 						role,
 					}),
 				}),
-			).rejects.toThrow("Invalid field name");
+			).rejects.toThrow("Could not retrieve field data");
 		});
 	});
 

--- a/test/integration/index.spec.ts
+++ b/test/integration/index.spec.ts
@@ -247,16 +247,16 @@ describe("setup", () => {
 				},
 			});
 
-			const post2 = await client.post.update({
-				where: {
-					id: postId2,
-				},
-				data: {
-					published: true,
-				},
-			});
-
-			expect(post2.published).toBe(false);
+			await expect(() =>
+				client.post.update({
+					where: {
+						id: postId2,
+					},
+					data: {
+						published: true,
+					},
+				}),
+			).rejects.toThrow("Record to update not found");
 		});
 
 		it("should be able to allow a role to delete a resource using a custom ability", async () => {

--- a/test/integration/rbac.spec.ts
+++ b/test/integration/rbac.spec.ts
@@ -298,17 +298,16 @@ describe("rbac", () => {
 				},
 			});
 
-			// Because the role can read the post, the update will silently fail and the post will not be updated.
-			// The Postgres docs indicate that an error should be thrown if the policy "WITH CHECK" expression fails, but this is not the case
-			// https://www.postgresql.org/docs/11/sql-createpolicy.html#SQL-CREATEPOLICY-UPDATE
-			await client.post.update({
-				where: { id: postId },
-				data: {
-					title: {
-						set: "lorem ipsum",
+			await expect(() =>
+				client.post.update({
+					where: { id: postId },
+					data: {
+						title: {
+							set: "lorem ipsum",
+						},
 					},
-				},
-			});
+				}),
+			).rejects.toThrow("Record to update not found");
 
 			const post = await client.post.findUnique({
 				where: { id: postId },


### PR DESCRIPTION
With this update, Yates now requires prisma v5. Under the hood not much has changed, except we now load data models from the private property `_runtimeDataModel`. I've imported the typings used for this internal data structure and reference the prisma test case that looks for it to try and prevent any problems that arise from using this private property.
The only major change I see is that previously, updates to a row protected by RLS would silently fail (the default PG behaviour), but now Prisma will throw a "Record to update not found" error. This is actually desirable, as it avoids some difficult to debug errors in ability logic.

BREAKING CHANGE: Yates now requires Prisma @ v5