### PR TITLE
feat: Add support for using the `in` operator with context values

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "tsc",
     "test": "rome ci src test",
     "lint:fix": "rome check --apply src test",
-    "test:integration": "jest test/integration",
+    "test:integration": "jest --runInBand test/integration",
     "test:compose:integration": "docker compose -f docker-compose.yml --profile with-sut up db sut --exit-code-from sut",
     "setup": "prisma generate && prisma migrate dev",
     "prepublishOnly": "npm run build"

--- a/src/ast-fragments.ts
+++ b/src/ast-fragments.ts
@@ -1,0 +1,80 @@
+import { escapeLiteral } from "./escape";
+
+/**
+ * Generates an AST fragment that will check if a column value exists in a JSONB array stored in a `current_setting`
+ * The AST fragment represents SQL that looks like this:
+ *  = ANY (SELECT jsonb_array_elements_text(current_setting('ctx.my_context_value')::jsonb))
+ */
+export const jsonb_array_elements_text = (setting: string) => {
+	return {
+		type: "function",
+		name: "ANY",
+		args: {
+			type: "expr_list",
+			value: [
+				{
+					ast: {
+						with: null,
+						type: "select",
+						options: null,
+						distinct: {
+							type: null,
+						},
+						columns: [
+							{
+								type: "expr",
+								expr: {
+									type: "function",
+									name: "jsonb_array_elements_text",
+									args: {
+										type: "expr_list",
+										value: [
+											{
+												type: "cast",
+												keyword: "cast",
+												expr: {
+													type: "function",
+													name: "current_setting",
+													args: {
+														type: "expr_list",
+														value: [
+															{
+																type: "parameter",
+																value: escapeLiteral(setting.replace(/^___yates_context_/, "")),
+															},
+														],
+													},
+												},
+												as: null,
+												symbol: "::",
+												target: {
+													dataType: "jsonb",
+												},
+												arrows: [],
+												properties: [],
+											},
+										],
+									},
+								},
+								as: null,
+							},
+						],
+						into: {
+							position: null,
+						},
+						from: null,
+						where: null,
+						groupby: null,
+						having: null,
+						orderby: null,
+						limit: {
+							seperator: "",
+							value: [],
+						},
+						window: null,
+					},
+				},
+			],
+		},
+	};
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,8 +111,17 @@ export const createClient = (prisma: PrismaClient, getContext: GetContextFn, opt
 									`Context variable "${k}" contains invalid characters. Context variables must only contain lowercase letters, numbers, periods and underscores.`,
 								);
 							}
-							if (typeof context[k] !== "number" && typeof context[k] !== "string") {
-								throw new Error(`Context variable "${k}" must be a string or number. Got ${typeof context[k]}`);
+							if (typeof context[k] !== "number" && typeof context[k] !== "string" && !Array.isArray(context[k])) {
+								throw new Error(`Context variable "${k}" must be a string, number or array. Got ${typeof context[k]}`);
+							}
+							if (Array.isArray(context[k])) {
+								for (const v of context[k] as any[]) {
+									if (typeof v !== "string") {
+										throw new Error(`Context variable "${k}" must be an array of strings. Got ${typeof v}`);
+									}
+								}
+								// Cast to a JSON string so that it can be used in RLS expressions
+								context[k] = JSON.stringify(context[k]);
 							}
 						}
 					}

--- a/test/integration/expressions.spec.ts
+++ b/test/integration/expressions.spec.ts
@@ -832,5 +832,82 @@ describe("expressions", () => {
 
 			expect(result2).toBeNull();
 		});
+
+		it("should be able to handle context values that are arrays", async () => {
+			const initial = new PrismaClient();
+
+			const role = `USER_${uuid()}`;
+
+			const testTitle1 = `test_${uuid()}`;
+			const testTitle2 = `test_${uuid()}`;
+
+			const client = await setup({
+				prisma: initial,
+				customAbilities: {
+					Post: {
+						customCreateAbility: {
+							description: "Create posts where there is already a tag label with the same title",
+							operation: "INSERT",
+							expression: (client: PrismaClient, _row, context) => {
+								return client.tag.findFirst({
+									where: {
+										label: {
+											in: context("post.title") as any as string[],
+										},
+									},
+								});
+							},
+						},
+					},
+				},
+				getRoles(abilities) {
+					return {
+						[role]: [abilities.Post.customCreateAbility, abilities.Post.read, abilities.Tag.read, abilities.Tag.create],
+					};
+				},
+				getContext: () => ({
+					role,
+					context: {
+						"post.title": [testTitle1, testTitle2],
+					},
+				}),
+			});
+
+			await expect(
+				client.post.create({
+					data: {
+						title: testTitle1,
+					},
+				}),
+			).rejects.toThrow();
+
+			await client.tag.create({
+				data: {
+					label: testTitle1,
+				},
+			});
+
+			const post1 = await client.post.create({
+				data: {
+					title: testTitle1,
+				},
+			});
+
+			expect(post1.id).toBeDefined();
+
+			await client.tag.create({
+				data: {
+					label: testTitle2,
+				},
+			});
+
+			const post2 = await client.post.create({
+				data: {
+					title: testTitle2,
+				},
+			});
+
+			expect(post2.id).toBeDefined();
+		});
 	});
 });

--- a/test/integration/expressions.spec.ts
+++ b/test/integration/expressions.spec.ts
@@ -909,7 +909,7 @@ describe("expressions", () => {
 				customAbilities: {
 					Post: {
 						customCreateAbility: {
-							description: "Create posts where there is already a tag label with the same title",
+							description: "Create posts where there is already a tag label with the same title from a known set",
 							operation: "INSERT",
 							expression: (client: PrismaClient, _row, context) => {
 								return client.tag.findFirst({


### PR DESCRIPTION
This change adds support for the `in` operator when using a context value in a prisma expression. This allows you to do useful stuff like allow a match against multiple contextually provided values (e.g. org membership).

e.g.

```ts
const client = await setup({
	prisma: initial,
	customAbilities: {
		Post: {
			customCreateAbility: {
				description: "Create posts where there is already a tag label with the same title",
				operation: "INSERT",
				expression: (client: PrismaClient, _row, context) => {
					return client.tag.findFirst({
						where: {
							label: {
								in: context("post.title"),
							},
						},
					});
				},
			},
		},
	},
	getRoles(abilities) {
		return {
			[role]: [abilities.Post.customCreateAbility, abilities.Post.read, abilities.Tag.read, abilities.Tag.create],
		};
	},
	getContext: () => ({
		role,
		context: {
			"post.title": [testTitle1, testTitle2],
		},
	}),
});
```