### PR TITLE
fix: correct postgres reference in escape.ts

### DIFF
--- a/src/escape.ts
+++ b/src/escape.ts
@@ -1,4 +1,4 @@
-// Source borrowed from node-postgrs (which borrows from PG itself)
+// Source borrowed from node-postgres (which borrows from PG itself)
 // https://github.com/brianc/node-postgres/blob/3f6760c62ee2a901d374b5e50c2f025b7d550315/packages/pg/lib/client.js#L408-L437
 // We need to manually escape strings because we're interpolating client values into SQL statements that don't support `PREPARE`, such as `CREATE POLICY`
 


### PR DESCRIPTION
## Summary
- correct `node-postgrs` typo in `escape.ts`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684fed9531e4832a8bf49f95be0ae6a9