### PR TITLE
Update actions/cache version

### DIFF
--- a/.github/workflows/publish-beta.yml
+++ b/.github/workflows/publish-beta.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: 20
 
       # Use a cache for dependencies
-      - uses: actions/cache@v3.3.1
+      - uses: actions/cache@v4
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
## Summary
- use `actions/cache@v4` in the `publish-beta` workflow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68500a88e964832a858a7d8e640c35ae