### PR TITLE
feat(rbac): add opt-in nested relation mutation guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Features
+
+* add opt-in `nestedRelationMutationGuard` to deny nested relation mutations unless explicitly allowed
+
 ## [3.8.1](https://github.com/cerebruminc/yates/compare/v3.8.0...v3.8.1) (2025-11-15)
 
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Yates applies permissions recursively across nested relations:
 
 - **Reads (`include`/`select`)**: Yates walks the selection tree and injects read filters for each related model. If the role has no read ability for a related model, the selection is dropped.
 - **Writes (nested create/update/delete/upsert)**: Yates validates each nested operation against the related model's abilities. For example, nested creates are checked against insert filters, and nested updates/deletes verify the target record is permitted before executing.
+  - You can additionally enable `nestedRelationMutationGuard` to deny nested relation mutations unless explicitly allowed.
 
 For accessing the context of a Prisma query, we recommend using a package like [cls-hooked](https://www.npmjs.com/package/cls-hooked) to store the context in the current session.
 
@@ -144,6 +145,31 @@ When defining an ability you need to provide the following properties:
   - For `INSERT` operations, the expression is matched against the incoming `data`.
   - For `SELECT`, `UPDATE` and `DELETE` operations, the expression is merged into the Prisma `where` clause.
 - `operation`: The operation that the ability is being applied to. This can be one of `INSERT`, `SELECT`, `UPDATE` or `DELETE`.
+
+### Nested relation mutation guard
+
+By default, Yates preserves existing nested relation mutation behavior for backwards compatibility.
+
+If you want Yates to deny nested relation mutations unless they are explicitly allowed, enable `nestedRelationMutationGuard`:
+
+```ts
+const client = await setup({
+  prisma,
+  getRoles: (abilities) => ({
+    USER: [abilities.Post.update],
+  }),
+  getContext: () => ({ role: "USER" }),
+  nestedRelationMutationGuard: {
+    enabled: true,
+    allow: ({ model, field, operation }) =>
+      model === "Post" && field === "tags" && operation === "connect",
+  },
+});
+```
+
+When `enabled: true` and no `allow` callback is provided, all nested relation mutations are denied.
+
+Covered nested operations: `connect`, `disconnect`, `set`, `create`, `createMany`, `connectOrCreate`, `upsert`, `delete`, `deleteMany`, `update`, `updateMany`.
 
 ### Debug
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,43 @@ export type GetContextFn<ContextKeys extends string = string> = () => {
 	};
 } | null;
 
+export const NESTED_RELATION_MUTATION_OPERATIONS = [
+	"connect",
+	"disconnect",
+	"set",
+	"create",
+	"createMany",
+	"connectOrCreate",
+	"upsert",
+	"delete",
+	"deleteMany",
+	"update",
+	"updateMany",
+] as const;
+
+export type NestedRelationMutationOperation =
+	(typeof NESTED_RELATION_MUTATION_OPERATIONS)[number];
+
+export interface NestedRelationMutationContext {
+	model: string;
+	field: string;
+	relatedModel: string;
+	operation: NestedRelationMutationOperation;
+}
+
+export interface NestedRelationMutationGuardOptions {
+	/**
+	 * Enables strict nested relation mutation checks.
+	 * When enabled, nested relation mutations are denied unless explicitly allowed via `allow`.
+	 */
+	enabled?: boolean;
+	/**
+	 * Explicit allow-list callback for nested relation mutations.
+	 * Returning `true` allows the mutation to proceed.
+	 */
+	allow?: (mutation: NestedRelationMutationContext) => boolean;
+}
+
 export interface SetupParams<
 	ContextKeys extends string = string,
 	YModels extends Models = Models,
@@ -83,6 +120,13 @@ export interface SetupParams<
 	 * Returning `null` will result in the permissions being skipped entirely.
 	 */
 	getContext: GetContextFn<ContextKeys>;
+	/**
+	 * Optional guard for nested relation mutations (`connect`, `disconnect`, `set`, `create`, `connectOrCreate`, `upsert`, etc).
+	 * Disabled by default for backwards compatibility.
+	 *
+	 * When enabled, nested relation mutations are denied unless explicitly allowed by `allow`.
+	 */
+	nestedRelationMutationGuard?: NestedRelationMutationGuardOptions;
 }
 
 // Sanitize a single string by ensuring the it has only lowercase alpha characters and underscores
@@ -128,6 +172,10 @@ const SELECT_OPERATIONS = new Set([
 	"aggregate",
 	"groupBy",
 ]);
+
+const NESTED_RELATION_MUTATION_OPERATION_SET = new Set<string>(
+	NESTED_RELATION_MUTATION_OPERATIONS,
+);
 
 const isPlainObject = (value: unknown): value is Record<string, any> =>
 	!!value && typeof value === "object" && !Array.isArray(value);
@@ -241,6 +289,12 @@ const permissionError = (model: string, operation: string) =>
 
 const updateNotFoundError = () => new Error("Record to update not found");
 const deleteNotFoundError = () => new Error("Record to delete does not exist");
+const nestedRelationMutationDeniedError = (
+	mutation: NestedRelationMutationContext,
+) =>
+	new Error(
+		`Nested relation mutation denied by Yates policy: ${mutation.model}.${mutation.field}.${mutation.operation}`,
+	);
 
 const matchesScalarFilter = (
 	value: any,
@@ -693,6 +747,26 @@ const assertRecordAllowed = async (
 	return !!record;
 };
 
+const assertNestedRelationMutationsAllowed = (
+	value: Record<string, any>,
+	mutationBase: Omit<NestedRelationMutationContext, "operation">,
+	guard?: NestedRelationMutationGuardOptions,
+) => {
+	if (!guard?.enabled) return;
+	for (const [operation, mutationValue] of Object.entries(value)) {
+		if (!NESTED_RELATION_MUTATION_OPERATION_SET.has(operation)) continue;
+		if (mutationValue === undefined) continue;
+		const mutation = {
+			...mutationBase,
+			operation: operation as NestedRelationMutationOperation,
+		};
+		const allowed = guard.allow?.(mutation) ?? false;
+		if (!allowed) {
+			throw nestedRelationMutationDeniedError(mutation);
+		}
+	}
+};
+
 const applyNestedWrites = async (
 	prisma: PrismaClient,
 	runtimeDataModel: RuntimeDataModel,
@@ -701,6 +775,7 @@ const applyNestedWrites = async (
 	model: string,
 	data: Record<string, any>,
 	context?: Record<string, string | number | string[]>,
+	nestedRelationMutationGuard?: NestedRelationMutationGuardOptions,
 ) => {
 	if (!isPlainObject(data)) return;
 	const fields = extractModelFields(runtimeDataModel, model);
@@ -709,6 +784,15 @@ const applyNestedWrites = async (
 		if (!fieldMeta || fieldMeta.kind !== "object") continue;
 		const relatedModel = fieldMeta.type as string;
 		if (!isPlainObject(value)) continue;
+		assertNestedRelationMutationsAllowed(
+			value,
+			{
+				model,
+				field,
+				relatedModel,
+			},
+			nestedRelationMutationGuard,
+		);
 
 		const handleCreate = async (createValue: any) => {
 			const items = Array.isArray(createValue) ? createValue : [createValue];
@@ -731,6 +815,7 @@ const applyNestedWrites = async (
 						relatedModel,
 						item,
 						context,
+						nestedRelationMutationGuard,
 					);
 				}
 			}
@@ -763,6 +848,7 @@ const applyNestedWrites = async (
 						relatedModel,
 						item.data,
 						context,
+						nestedRelationMutationGuard,
 					);
 				}
 			}
@@ -828,6 +914,7 @@ const applyNestedWrites = async (
 						relatedModel,
 						item.data,
 						context,
+						nestedRelationMutationGuard,
 					);
 				}
 			}
@@ -857,6 +944,7 @@ const applyNestedWrites = async (
 							relatedModel,
 							item.update,
 							context,
+							nestedRelationMutationGuard,
 						);
 					}
 				} else {
@@ -878,6 +966,7 @@ const applyNestedWrites = async (
 							relatedModel,
 							item.create,
 							context,
+							nestedRelationMutationGuard,
 						);
 					} else {
 						throw updateNotFoundError();
@@ -993,7 +1082,13 @@ export const setup = async <
 ) => {
 	const start = performance.now();
 
-	const { prisma, customAbilities, getRoles, getContext } = params;
+	const {
+		prisma,
+		customAbilities,
+		getRoles,
+		getContext,
+		nestedRelationMutationGuard,
+	} = params;
 	const yates = new Yates(prisma);
 	const runtimeDataModel = yates.inspectRunTimeDataModel();
 	const models = Object.keys(runtimeDataModel.models).map(
@@ -1205,6 +1300,7 @@ export const setup = async <
 								model,
 								queryArgs.data,
 								context,
+								nestedRelationMutationGuard,
 							);
 							return query(args);
 						}
@@ -1230,6 +1326,7 @@ export const setup = async <
 									model,
 									item,
 									context,
+									nestedRelationMutationGuard,
 								);
 							}
 							return query(args);
@@ -1258,6 +1355,7 @@ export const setup = async <
 									model,
 									queryArgs.data,
 									context,
+									nestedRelationMutationGuard,
 								);
 							}
 							return query(args);
@@ -1290,6 +1388,7 @@ export const setup = async <
 									model,
 									queryArgs.data,
 									context,
+									nestedRelationMutationGuard,
 								);
 							}
 							return query(args);
@@ -1315,6 +1414,7 @@ export const setup = async <
 										model,
 										args.update,
 										context,
+										nestedRelationMutationGuard,
 									);
 								}
 							} else {
@@ -1336,6 +1436,7 @@ export const setup = async <
 										model,
 										args.create,
 										context,
+										nestedRelationMutationGuard,
 									);
 								} else {
 									throw updateNotFoundError();

--- a/test/integration/nested-relation-mutation-guard.spec.ts
+++ b/test/integration/nested-relation-mutation-guard.spec.ts
@@ -1,0 +1,118 @@
+import { PrismaClient } from "@prisma/client";
+import { v4 as uuid } from "uuid";
+import { setup } from "../../src";
+
+let adminClient: PrismaClient;
+
+beforeAll(async () => {
+	adminClient = new PrismaClient();
+});
+
+afterAll(async () => {
+	await adminClient.$disconnect();
+});
+
+const createUpdateClient = async (
+	role: string,
+	postId: number,
+	nestedRelationMutationGuard?: Parameters<
+		typeof setup
+	>[0]["nestedRelationMutationGuard"],
+) =>
+	setup({
+		prisma: new PrismaClient(),
+		customAbilities: {
+			Post: {
+				updateOne: {
+					description: "Update a single post",
+					operation: "UPDATE",
+					expression: () => ({ id: postId }),
+				},
+			},
+		},
+		getRoles: (abilities) => ({
+			[role]: [abilities.Post.updateOne as any],
+		}),
+		getContext: () => ({ role, context: {} }),
+		nestedRelationMutationGuard,
+	});
+
+describe("nested relation mutation guard", () => {
+	it("blocks implicit many-to-many nested connect when enabled", async () => {
+		const role = `USER_${uuid()}`;
+		const post = await adminClient.post.create({
+			data: { title: `post-${uuid()}` },
+		});
+		const tag = await adminClient.tag.create({
+			data: { label: `tag-${uuid()}` },
+		});
+
+		const client = await createUpdateClient(role, post.id, { enabled: true });
+
+		await expect(
+			client.post.update({
+				where: { id: post.id },
+				data: {
+					tags: {
+						connect: { id: tag.id },
+					},
+				},
+			}),
+		).rejects.toThrow("Nested relation mutation denied by Yates policy");
+
+		const persisted = await adminClient.post.findUnique({
+			where: { id: post.id },
+			include: { tags: true },
+		});
+
+		expect(persisted?.tags).toHaveLength(0);
+	});
+
+	it("allows normal scalar updates when guard is enabled", async () => {
+		const role = `USER_${uuid()}`;
+		const post = await adminClient.post.create({
+			data: { title: `post-${uuid()}` },
+		});
+		const nextTitle = `updated-${uuid()}`;
+
+		const client = await createUpdateClient(role, post.id, { enabled: true });
+
+		const updated = await client.post.update({
+			where: { id: post.id },
+			data: { title: nextTitle },
+		});
+
+		expect(updated.title).toBe(nextTitle);
+	});
+
+	it("keeps existing nested relation mutation behavior when option is disabled", async () => {
+		const role = `USER_${uuid()}`;
+		const post = await adminClient.post.create({
+			data: { title: `post-${uuid()}` },
+		});
+		const tag = await adminClient.tag.create({
+			data: { label: `tag-${uuid()}` },
+		});
+
+		const client = await createUpdateClient(role, post.id);
+
+		await expect(
+			client.post.update({
+				where: { id: post.id },
+				data: {
+					tags: {
+						connect: { id: tag.id },
+					},
+				},
+			}),
+		).resolves.toBeDefined();
+
+		const persisted = await adminClient.post.findUnique({
+			where: { id: post.id },
+			include: { tags: true },
+		});
+
+		expect(persisted?.tags).toHaveLength(1);
+		expect(persisted?.tags[0]?.id).toBe(tag.id);
+	});
+});


### PR DESCRIPTION
## Summary
- add an opt-in `nestedRelationMutationGuard` option to `setup(...)`
- when enabled, deny nested relation mutation operations unless explicitly allowlisted
- keep backwards compatibility by leaving this feature disabled by default
- document new behavior in README and CHANGELOG

## Tests
- `npx jest --runInBand test/integration/coverage.spec.ts test/integration/nested-relation-mutation-guard.spec.ts`

## Notes
- adds coverage for implicit many-to-many nested connect blocking, scalar update pass-through, and disabled-mode backward compatibility
